### PR TITLE
Implement validation and merge utilities

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,10 @@ dependencies {
     implementation("io.quarkus:quarkus-jdbc-postgresql")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("io.quarkus:quarkus-arc")
+    implementation("com.networknt:json-schema-validator:1.5.6")
+
     testImplementation("io.quarkus:quarkus-junit5")
+    testImplementation("org.jetbrains.kotlin:kotlin-test")
 }
 
 group = "org.fg"

--- a/src/main/kotlin/org/fg/ttrpg/infra/merge/MergeService.kt
+++ b/src/main/kotlin/org/fg/ttrpg/infra/merge/MergeService.kt
@@ -1,0 +1,44 @@
+package org.fg.ttrpg.infra.merge
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
+import jakarta.enterprise.context.ApplicationScoped
+
+/**
+ * Performs JSON Merge Patch (RFC 7396).
+ */
+@ApplicationScoped
+class MergeService {
+    private val mapper = ObjectMapper()
+
+    /**
+     * Apply a JSON Merge Patch to an original JSON document.
+     */
+    fun merge(original: JsonNode, patch: JsonNode): JsonNode {
+        if (!patch.isObject) {
+            // Per RFC 7396 section 2
+            return patch
+        }
+        val target = original.deepCopy<ObjectNode>()
+        patch.fields().forEach { (name, value) ->
+            if (value.isNull) {
+                target.remove(name)
+            } else {
+                val existing = target.get(name)
+                if (existing != null && existing.isObject && value.isObject) {
+                    target.replace(name, merge(existing, value))
+                } else {
+                    target.replace(name, value)
+                }
+            }
+        }
+        return target
+    }
+
+    fun merge(original: String, patch: String): String {
+        val origNode = mapper.readTree(original)
+        val patchNode = mapper.readTree(patch)
+        return merge(origNode, patchNode).toString()
+    }
+}

--- a/src/main/kotlin/org/fg/ttrpg/infra/validation/TemplateSchemaRepository.kt
+++ b/src/main/kotlin/org/fg/ttrpg/infra/validation/TemplateSchemaRepository.kt
@@ -1,0 +1,8 @@
+package org.fg.ttrpg.infra.validation
+
+/**
+ * Simple abstraction for loading JSON Schema documents for templates.
+ */
+interface TemplateSchemaRepository {
+    fun findSchema(templateId: Long): String?
+}

--- a/src/main/kotlin/org/fg/ttrpg/infra/validation/TemplateValidator.kt
+++ b/src/main/kotlin/org/fg/ttrpg/infra/validation/TemplateValidator.kt
@@ -1,0 +1,45 @@
+package org.fg.ttrpg.infra.validation
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.networknt.schema.JsonSchema
+import com.networknt.schema.JsonSchemaFactory
+import com.networknt.schema.SpecVersion
+import com.networknt.schema.ValidationMessage
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+
+/**
+ * Validates payloads against template JSON Schema documents using a small LRU cache.
+ */
+@ApplicationScoped
+class TemplateValidator @Inject constructor(
+    private val repository: TemplateSchemaRepository
+) {
+    companion object {
+        private const val CACHE_SIZE = 32
+    }
+
+    private val mapper = ObjectMapper()
+    private val factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012)
+
+    private val cache = object : LinkedHashMap<Long, JsonSchema>(CACHE_SIZE, 0.75f, true) {
+        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<Long, JsonSchema>?) =
+            size > CACHE_SIZE
+    }
+
+    fun validate(templateId: Long, payload: JsonNode) {
+        val schema = cache.computeIfAbsent(templateId) {
+            val schemaText = repository.findSchema(templateId)
+                ?: throw IllegalArgumentException("Schema not found for template $templateId")
+            factory.getSchema(mapper.readTree(schemaText))
+        }
+        val errors = schema.validate(payload)
+        if (errors.isNotEmpty()) {
+            throw TemplateValidationException(errors)
+        }
+    }
+}
+
+class TemplateValidationException(val violations: Set<ValidationMessage>) :
+    RuntimeException(violations.joinToString("; ") { it.message })

--- a/src/main/kotlin/org/fg/ttrpg/setting/Template.kt
+++ b/src/main/kotlin/org/fg/ttrpg/setting/Template.kt
@@ -9,6 +9,9 @@ class Template : PanacheEntity() {
     lateinit var name: String
     var description: String? = null
 
+    /** JSON schema describing objects of this template */
+    var schema: String? = null
+
     @ManyToOne
     lateinit var setting: Setting
 }

--- a/src/test/kotlin/org/fg/ttrpg/infra/MergeServiceTest.kt
+++ b/src/test/kotlin/org/fg/ttrpg/infra/MergeServiceTest.kt
@@ -1,0 +1,21 @@
+package org.fg.ttrpg.infra
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.fg.ttrpg.infra.merge.MergeService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class MergeServiceTest {
+    private val mapper = ObjectMapper()
+    private val service = MergeService()
+
+    @Test
+    fun `merge patch replaces and removes`() {
+        val original = """{"name":"old","extra":"keep"}"""
+        val patch = """{"name":"new","extra":null}"""
+        val result = mapper.readTree(service.merge(original, patch))
+        assertEquals("new", result.get("name").asText())
+        // removed field should be null
+        assertEquals(null, result.get("extra"))
+    }
+}

--- a/src/test/kotlin/org/fg/ttrpg/infra/TemplateValidatorTest.kt
+++ b/src/test/kotlin/org/fg/ttrpg/infra/TemplateValidatorTest.kt
@@ -1,0 +1,28 @@
+package org.fg.ttrpg.infra
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.fg.ttrpg.infra.validation.TemplateSchemaRepository
+import org.fg.ttrpg.infra.validation.TemplateValidationException
+import org.fg.ttrpg.infra.validation.TemplateValidator
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+class TemplateValidatorTest {
+    private val mapper = ObjectMapper()
+
+    @Test
+    fun `invalid payload throws`() {
+        val repo = object : TemplateSchemaRepository {
+            override fun findSchema(templateId: Long): String? = """{
+                "type": "object",
+                "required": ["name"],
+                "properties": { "name": {"type": "string"} }
+            }"""
+        }
+        val validator = TemplateValidator(repo)
+        val payload = mapper.readTree("{}")
+        assertThrows(TemplateValidationException::class.java) {
+            validator.validate(1L, payload)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extend `Template` with `schema` field
- create `TemplateValidator` with LRU-cached JSON Schema support
- add `MergeService` for JSON Merge Patch
- test validation failures
- test merge results

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68591dc929788325bccdd70f0ec237d6