### PR TITLE
Implement REST controllers

### DIFF
--- a/src/main/kotlin/org/fg/ttrpg/campaign/resource/CampaignResource.kt
+++ b/src/main/kotlin/org/fg/ttrpg/campaign/resource/CampaignResource.kt
@@ -1,0 +1,56 @@
+package org.fg.ttrpg.campaign.resource
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import jakarta.inject.Inject
+import jakarta.transaction.Transactional
+import jakarta.ws.rs.*
+import jakarta.ws.rs.core.MediaType
+import org.fg.ttrpg.campaign.Campaign
+import org.fg.ttrpg.campaign.CampaignObject
+import org.fg.ttrpg.campaign.CampaignObjectRepository
+import org.fg.ttrpg.campaign.CampaignService
+import org.fg.ttrpg.common.dto.CampaignDTO
+import org.fg.ttrpg.common.dto.CampaignObjectDTO
+import org.fg.ttrpg.infra.merge.MergeService
+import org.fg.ttrpg.infra.validation.TemplateValidator
+
+@Path("/api/campaigns")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+class CampaignResource @Inject constructor(
+    private val service: CampaignService,
+    private val objectRepo: CampaignObjectRepository,
+    private val merge: MergeService,
+    private val validator: TemplateValidator
+) {
+    private val mapper = ObjectMapper()
+
+    @GET
+    @Path("{id}")
+    fun find(@PathParam("id") id: Long): CampaignDTO {
+        val campaign = service.findById(id) ?: throw NotFoundException()
+        return campaign.toDto()
+    }
+
+    @PATCH
+    @Path("{id}/objects/{oid}")
+    @Transactional
+    fun patchObject(
+        @PathParam("id") id: Long,
+        @PathParam("oid") oid: Long,
+        patch: String
+    ): CampaignObjectDTO {
+        service.findById(id) ?: throw NotFoundException()
+        val obj = objectRepo.findById(oid) ?: throw NotFoundException()
+        val merged = merge.merge(mapper.writeValueAsString(obj), patch)
+        val node = mapper.readTree(merged)
+        validator.validate(obj.settingObject.id!!, node)
+        obj.name = node.get("name")?.asText() ?: obj.name
+        obj.description = node.get("description")?.asText()
+        return obj.toDto()
+    }
+}
+
+private fun Campaign.toDto() = CampaignDTO(id, name, gm.id!!, setting.id!!)
+private fun CampaignObject.toDto() =
+    CampaignObjectDTO(id, name, description, campaign.id!!, settingObject.id!!)

--- a/src/main/kotlin/org/fg/ttrpg/common/dto/CampaignDTO.kt
+++ b/src/main/kotlin/org/fg/ttrpg/common/dto/CampaignDTO.kt
@@ -1,0 +1,8 @@
+package org.fg.ttrpg.common.dto
+
+data class CampaignDTO(
+    val id: Long?,
+    val name: String,
+    val gmId: Long,
+    val settingId: Long
+)

--- a/src/main/kotlin/org/fg/ttrpg/common/dto/CampaignObjectDTO.kt
+++ b/src/main/kotlin/org/fg/ttrpg/common/dto/CampaignObjectDTO.kt
@@ -1,0 +1,9 @@
+package org.fg.ttrpg.common.dto
+
+data class CampaignObjectDTO(
+    val id: Long?,
+    val name: String,
+    val description: String? = null,
+    val campaignId: Long,
+    val settingObjectId: Long
+)

--- a/src/main/kotlin/org/fg/ttrpg/common/dto/SettingDTO.kt
+++ b/src/main/kotlin/org/fg/ttrpg/common/dto/SettingDTO.kt
@@ -1,0 +1,7 @@
+package org.fg.ttrpg.common.dto
+
+data class SettingDTO(
+    val id: Long?,
+    val name: String,
+    val description: String? = null
+)

--- a/src/main/kotlin/org/fg/ttrpg/common/dto/SettingObjectDTO.kt
+++ b/src/main/kotlin/org/fg/ttrpg/common/dto/SettingObjectDTO.kt
@@ -1,0 +1,8 @@
+package org.fg.ttrpg.common.dto
+
+data class SettingObjectDTO(
+    val id: Long?,
+    val name: String,
+    val description: String? = null,
+    val settingId: Long
+)

--- a/src/main/kotlin/org/fg/ttrpg/common/dto/TemplateDTO.kt
+++ b/src/main/kotlin/org/fg/ttrpg/common/dto/TemplateDTO.kt
@@ -1,0 +1,9 @@
+package org.fg.ttrpg.common.dto
+
+data class TemplateDTO(
+    val id: Long?,
+    val name: String,
+    val description: String? = null,
+    val schema: String? = null,
+    val settingId: Long
+)

--- a/src/main/kotlin/org/fg/ttrpg/infra/validation/DatabaseTemplateSchemaRepository.kt
+++ b/src/main/kotlin/org/fg/ttrpg/infra/validation/DatabaseTemplateSchemaRepository.kt
@@ -1,0 +1,13 @@
+package org.fg.ttrpg.infra.validation
+
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import org.fg.ttrpg.setting.TemplateRepository
+
+@ApplicationScoped
+class DatabaseTemplateSchemaRepository @Inject constructor(
+    private val templates: TemplateRepository
+) : TemplateSchemaRepository {
+    override fun findSchema(templateId: Long): String? =
+        templates.findById(templateId)?.schema
+}

--- a/src/main/kotlin/org/fg/ttrpg/setting/resource/SettingResource.kt
+++ b/src/main/kotlin/org/fg/ttrpg/setting/resource/SettingResource.kt
@@ -1,0 +1,53 @@
+package org.fg.ttrpg.setting.resource
+
+import jakarta.inject.Inject
+import jakarta.transaction.Transactional
+import jakarta.ws.rs.*
+import jakarta.ws.rs.core.MediaType
+import org.fg.ttrpg.common.dto.SettingDTO
+import org.fg.ttrpg.common.dto.SettingObjectDTO
+import org.fg.ttrpg.setting.Setting
+import org.fg.ttrpg.setting.SettingObject
+import org.fg.ttrpg.setting.SettingObjectRepository
+import org.fg.ttrpg.setting.SettingService
+
+@Path("/api/settings")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+class SettingResource @Inject constructor(
+    private val service: SettingService,
+    private val objectRepo: SettingObjectRepository
+) {
+    @GET
+    fun list(): List<SettingDTO> =
+        service.listAll().map { it.toDto() }
+
+    @POST
+    @Transactional
+    fun create(dto: SettingDTO): SettingDTO {
+        val entity = Setting().apply {
+            name = dto.name
+            description = dto.description
+        }
+        service.persist(entity)
+        return entity.toDto()
+    }
+
+    @POST
+    @Path("{id}/objects")
+    @Transactional
+    fun createObject(@PathParam("id") id: Long, dto: SettingObjectDTO): SettingObjectDTO {
+        val setting = service.findById(id) ?: throw NotFoundException()
+        val obj = SettingObject().apply {
+            name = dto.name
+            description = dto.description
+            this.setting = setting
+        }
+        objectRepo.persist(obj)
+        return obj.toDto()
+    }
+}
+
+private fun Setting.toDto() = SettingDTO(id, name, description)
+private fun SettingObject.toDto() =
+    SettingObjectDTO(id, name, description, setting.id!!)

--- a/src/main/kotlin/org/fg/ttrpg/setting/resource/TemplateResource.kt
+++ b/src/main/kotlin/org/fg/ttrpg/setting/resource/TemplateResource.kt
@@ -1,0 +1,30 @@
+package org.fg.ttrpg.setting.resource
+
+import jakarta.inject.Inject
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.QueryParam
+import jakarta.ws.rs.core.MediaType
+import org.fg.ttrpg.common.dto.TemplateDTO
+import org.fg.ttrpg.setting.Template
+import org.fg.ttrpg.setting.TemplateRepository
+
+@Path("/api/templates")
+@Produces(MediaType.APPLICATION_JSON)
+class TemplateResource @Inject constructor(
+    private val templates: TemplateRepository
+) {
+    @GET
+    fun list(@QueryParam("settingId") settingId: Long?): List<TemplateDTO> {
+        val list = if (settingId != null) {
+            templates.list("setting.id", settingId)
+        } else {
+            templates.listAll()
+        }
+        return list.map { it.toDto() }
+    }
+}
+
+private fun Template.toDto() =
+    TemplateDTO(id, name, description, schema, setting.id!!)


### PR DESCRIPTION
## Summary
- add DTO classes in `common` package
- implement REST resources for Settings, Campaigns and Templates
- provide a database-backed TemplateSchemaRepository
- expose APIs for listing, creating and patching entities

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68592155c21c832587dd72c284db7c25