### PR TITLE
Switch genre setting relation to ManyToOne

### DIFF
--- a/src/main/kotlin/org/fg/ttrpg/genre/Genre.kt
+++ b/src/main/kotlin/org/fg/ttrpg/genre/Genre.kt
@@ -3,7 +3,7 @@ package org.fg.ttrpg.genre
 import io.quarkus.hibernate.orm.panache.kotlin.PanacheEntityBase
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
-import jakarta.persistence.ManyToMany
+import jakarta.persistence.ManyToOne
 import java.util.UUID
 
 @Entity
@@ -12,6 +12,6 @@ class Genre  {
     var id: UUID? = null
     var name: String? = null
 
-    @ManyToMany(mappedBy = "genres")
-    var settings: MutableList<org.fg.ttrpg.setting.Setting> = mutableListOf()
+    @ManyToOne
+    var setting: org.fg.ttrpg.setting.Setting? = null
 }

--- a/src/main/kotlin/org/fg/ttrpg/setting/Setting.kt
+++ b/src/main/kotlin/org/fg/ttrpg/setting/Setting.kt
@@ -3,7 +3,6 @@ package org.fg.ttrpg.setting
 import io.quarkus.hibernate.orm.panache.kotlin.PanacheEntityBase
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
-import jakarta.persistence.ManyToMany
 import jakarta.persistence.OneToMany
 import java.util.UUID
 
@@ -14,7 +13,7 @@ class Setting  {
     var name: String? = null
     var description: String? = null
 
-    @ManyToMany
+    @OneToMany(mappedBy = "setting")
     var genres: MutableList<org.fg.ttrpg.genre.Genre> = mutableListOf()
 
     @OneToMany(mappedBy = "setting")

--- a/src/main/resources/db/changelog/1-init.sql
+++ b/src/main/resources/db/changelog/1-init.sql
@@ -15,13 +15,8 @@ CREATE TABLE setting (
 
 CREATE TABLE genre (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    name VARCHAR(255) NOT NULL
-);
-
-CREATE TABLE setting_genre (
-    setting_id UUID NOT NULL REFERENCES setting(id),
-    genre_id UUID NOT NULL REFERENCES genre(id),
-    PRIMARY KEY (setting_id, genre_id)
+    name VARCHAR(255) NOT NULL,
+    setting_id UUID NOT NULL REFERENCES setting(id)
 );
 
 CREATE TABLE template (

--- a/src/test/kotlin/org/fg/ttrpg/repository/RepositoryIT.kt
+++ b/src/test/kotlin/org/fg/ttrpg/repository/RepositoryIT.kt
@@ -43,18 +43,18 @@ class RepositoryIT {
         }
         gmRepo.persist(gm)
 
-        val genre = Genre().apply {
-            id = UUID.randomUUID()
-            name = "fantasy"
-        }
-        genreRepo.persist(genre)
-
         val setting = Setting().apply {
             id = UUID.randomUUID()
             name = "world"
-            genres.add(genre)
         }
         settingRepo.persist(setting)
+
+        val genre = Genre().apply {
+            id = UUID.randomUUID()
+            name = "fantasy"
+            this.setting = setting
+        }
+        genreRepo.persist(genre)
 
         val template = Template().apply {
             id = UUID.randomUUID()


### PR DESCRIPTION
## Summary
- replace setting/genre join table with a `@ManyToOne` relation on `Genre`
- update `Setting` to map genres with `@OneToMany`
- adjust initial Liquibase SQL
- fix repository integration test for new relation

## Testing
- `./gradlew test --no-daemon` *(fails: PSQLException ConnectException)*

------
https://chatgpt.com/codex/tasks/task_e_6859385c8c888325971fb72414ddf5b6