### PR TITLE
Add GM field to Setting

### DIFF
--- a/src/main/kotlin/org/fg/ttrpg/common/dto/SettingDTO.kt
+++ b/src/main/kotlin/org/fg/ttrpg/common/dto/SettingDTO.kt
@@ -5,5 +5,6 @@ import java.util.UUID
 data class SettingDTO(
     val id: UUID?,
     val name: String,
-    val description: String? = null
+    val description: String? = null,
+    val gmId: UUID
 )

--- a/src/main/kotlin/org/fg/ttrpg/setting/Setting.kt
+++ b/src/main/kotlin/org/fg/ttrpg/setting/Setting.kt
@@ -4,6 +4,7 @@ import io.quarkus.hibernate.orm.panache.kotlin.PanacheEntityBase
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.ManyToMany
+import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
 import java.util.UUID
 
@@ -13,6 +14,9 @@ class Setting  {
     var id: UUID? = null
     var name: String? = null
     var description: String? = null
+
+    @ManyToOne
+    var gm: org.fg.ttrpg.account.GM? = null
 
     @ManyToMany
     var genres: MutableList<org.fg.ttrpg.genre.Genre> = mutableListOf()

--- a/src/main/kotlin/org/fg/ttrpg/setting/resource/SettingResource.kt
+++ b/src/main/kotlin/org/fg/ttrpg/setting/resource/SettingResource.kt
@@ -6,6 +6,7 @@ import jakarta.ws.rs.*
 import jakarta.ws.rs.core.MediaType
 import org.fg.ttrpg.common.dto.SettingDTO
 import org.fg.ttrpg.common.dto.SettingObjectDTO
+import org.fg.ttrpg.account.GMRepository
 import org.fg.ttrpg.setting.Setting
 import org.fg.ttrpg.setting.SettingObject
 import org.fg.ttrpg.setting.SettingObjectRepository
@@ -17,7 +18,8 @@ import java.util.UUID
 @Consumes(MediaType.APPLICATION_JSON)
 class SettingResource @Inject constructor(
     private val service: SettingService,
-    private val objectRepo: SettingObjectRepository
+    private val objectRepo: SettingObjectRepository,
+    private val gmRepo: GMRepository
 ) {
     @GET
     fun list(): List<SettingDTO> =
@@ -26,9 +28,11 @@ class SettingResource @Inject constructor(
     @POST
     @Transactional
     fun create(dto: SettingDTO): SettingDTO {
+        val gm = gmRepo.findById(dto.gmId) ?: throw NotFoundException()
         val entity = Setting().apply {
             name = dto.name
             description = dto.description
+            this.gm = gm
         }
         service.persist(entity)
         return entity.toDto()
@@ -49,6 +53,7 @@ class SettingResource @Inject constructor(
     }
 }
 
-private fun Setting.toDto() = SettingDTO(id, name ?: "", description)
+private fun Setting.toDto() =
+    SettingDTO(id, name ?: "", description, gm?.id ?: error("GM is null"))
 private fun SettingObject.toDto() =
     SettingObjectDTO(id, name ?: "", description, setting?.id ?: error("Setting is null"))

--- a/src/main/resources/db/changelog/1-init.sql
+++ b/src/main/resources/db/changelog/1-init.sql
@@ -10,7 +10,8 @@ CREATE TABLE gm (
 CREATE TABLE setting (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     name VARCHAR(255) NOT NULL,
-    description TEXT
+    description TEXT,
+    gm_id UUID REFERENCES gm(id)
 );
 
 CREATE TABLE genre (

--- a/src/test/kotlin/org/fg/ttrpg/repository/RepositoryIT.kt
+++ b/src/test/kotlin/org/fg/ttrpg/repository/RepositoryIT.kt
@@ -52,6 +52,7 @@ class RepositoryIT {
         val setting = Setting().apply {
             id = UUID.randomUUID()
             name = "world"
+            this.gm = gm
             genres.add(genre)
         }
         settingRepo.persist(setting)
@@ -89,6 +90,7 @@ class RepositoryIT {
         gmRepo.count() shouldBe 1
         genreRepo.count() shouldBe 1
         settingRepo.count() shouldBe 1
+        settingRepo.findById(setting.id!!)?.gm?.id shouldBe gm.id
         templateRepo.count() shouldBe 1
         settingObjectRepo.count() shouldBe 1
         campaignRepo.count() shouldBe 1


### PR DESCRIPTION
## Summary
- link Setting entities to a GM account
- expose gmId via SettingDTO and resource endpoints
- record GM foreign key in database schema
- test GM linkage when persisting settings

## Testing
- `./gradlew test` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6859385ba9208325b569ea41a2e3ca81