### PR TITLE
Add new SettingObject fields

### DIFF
--- a/src/main/kotlin/org/fg/ttrpg/common/dto/SettingObjectDTO.kt
+++ b/src/main/kotlin/org/fg/ttrpg/common/dto/SettingObjectDTO.kt
@@ -4,7 +4,11 @@ import java.util.UUID
 
 data class SettingObjectDTO(
     val id: UUID?,
+    val slug: String,
     val name: String,
     val description: String? = null,
-    val settingId: UUID
+    val payload: String? = null,
+    val tags: List<String> = emptyList(),
+    val settingId: UUID,
+    val templateId: UUID? = null
 )

--- a/src/main/kotlin/org/fg/ttrpg/setting/SettingObject.kt
+++ b/src/main/kotlin/org/fg/ttrpg/setting/SettingObject.kt
@@ -1,18 +1,28 @@
 package org.fg.ttrpg.setting
 
 import io.quarkus.hibernate.orm.panache.kotlin.PanacheEntityBase
-import jakarta.persistence.Entity
-import jakarta.persistence.Id
-import jakarta.persistence.ManyToOne
+import jakarta.persistence.*
 import java.util.UUID
 
 @Entity
 class SettingObject  {
     @Id
     var id: UUID? = null
+    var slug: String? = null
     var name: String? = null
     var description: String? = null
+    /** Arbitrary JSON payload describing this object */
+    @Column(columnDefinition = "jsonb")
+    var payload: String? = null
+
+    @ElementCollection
+    @CollectionTable(name = "setting_object_tags", joinColumns = [JoinColumn(name = "setting_object_id")])
+    @Column(name = "tag")
+    var tags: MutableList<String> = mutableListOf()
 
     @ManyToOne
     var setting: Setting? = null
+
+    @ManyToOne
+    var template: Template? = null
 }

--- a/src/main/kotlin/org/fg/ttrpg/setting/resource/SettingResource.kt
+++ b/src/main/kotlin/org/fg/ttrpg/setting/resource/SettingResource.kt
@@ -6,10 +6,7 @@ import jakarta.ws.rs.*
 import jakarta.ws.rs.core.MediaType
 import org.fg.ttrpg.common.dto.SettingDTO
 import org.fg.ttrpg.common.dto.SettingObjectDTO
-import org.fg.ttrpg.setting.Setting
-import org.fg.ttrpg.setting.SettingObject
-import org.fg.ttrpg.setting.SettingObjectRepository
-import org.fg.ttrpg.setting.SettingService
+import org.fg.ttrpg.setting.*
 import java.util.UUID
 
 @Path("/api/settings")
@@ -17,7 +14,8 @@ import java.util.UUID
 @Consumes(MediaType.APPLICATION_JSON)
 class SettingResource @Inject constructor(
     private val service: SettingService,
-    private val objectRepo: SettingObjectRepository
+    private val objectRepo: SettingObjectRepository,
+    private val templateRepo: TemplateRepository
 ) {
     @GET
     fun list(): List<SettingDTO> =
@@ -39,10 +37,15 @@ class SettingResource @Inject constructor(
     @Transactional
     fun createObject(@PathParam("id") id: UUID, dto: SettingObjectDTO): SettingObjectDTO {
         val setting = service.findById(id) ?: throw NotFoundException()
+        val template = dto.templateId?.let { templateRepo.findById(it) } ?: dto.templateId?.let { throw NotFoundException() }
         val obj = SettingObject().apply {
+            slug = dto.slug
             name = dto.name
             description = dto.description
+            payload = dto.payload
+            tags = dto.tags.toMutableList()
             this.setting = setting
+            this.template = template
         }
         objectRepo.persist(obj)
         return obj.toDto()
@@ -51,4 +54,13 @@ class SettingResource @Inject constructor(
 
 private fun Setting.toDto() = SettingDTO(id, name ?: "", description)
 private fun SettingObject.toDto() =
-    SettingObjectDTO(id, name ?: "", description, setting?.id ?: error("Setting is null"))
+    SettingObjectDTO(
+        id,
+        slug ?: "",
+        name ?: "",
+        description,
+        payload,
+        tags.toList(),
+        setting?.id ?: error("Setting is null"),
+        template?.id
+    )

--- a/src/main/resources/db/changelog/1-init.sql
+++ b/src/main/resources/db/changelog/1-init.sql
@@ -35,9 +35,18 @@ CREATE INDEX template_schema_gin_idx ON template USING GIN (schema);
 
 CREATE TABLE setting_object (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    slug VARCHAR(255) NOT NULL,
     name VARCHAR(255) NOT NULL,
     description TEXT,
+    payload JSONB,
+    template_id UUID REFERENCES template(id),
     setting_id UUID NOT NULL REFERENCES setting(id)
+);
+CREATE INDEX setting_object_payload_gin_idx ON setting_object USING GIN (payload);
+
+CREATE TABLE setting_object_tags (
+    setting_object_id UUID NOT NULL REFERENCES setting_object(id),
+    tag VARCHAR(255) NOT NULL
 );
 
 CREATE TABLE campaign (

--- a/src/test/kotlin/org/fg/ttrpg/repository/RepositoryIT.kt
+++ b/src/test/kotlin/org/fg/ttrpg/repository/RepositoryIT.kt
@@ -65,8 +65,12 @@ class RepositoryIT {
 
         val settingObject = SettingObject().apply {
             id = UUID.randomUUID()
+            slug = "object-slug"
             name = "object"
+            payload = "{}"
+            tags = mutableListOf("a", "b")
             this.setting = setting
+            this.template = template
         }
         settingObjectRepo.persist(settingObject)
 


### PR DESCRIPTION
## Summary
- introduce slug, payload and tags for SettingObject
- allow SettingObjects to reference Templates
- expose new fields in SettingResource API
- update Liquibase init script
- update RepositoryIT test

## Testing
- `./gradlew test` *(fails: Connection refused to localhost:5432)*

------
https://chatgpt.com/codex/tasks/task_e_6859385fd85483258400e4c77bccadac