### PR TITLE
Add payload support for campaign objects

### DIFF
--- a/src/main/kotlin/org/fg/ttrpg/campaign/CampaignObject.kt
+++ b/src/main/kotlin/org/fg/ttrpg/campaign/CampaignObject.kt
@@ -18,4 +18,12 @@ class CampaignObject {
 
     @ManyToOne
     var settingObject: org.fg.ttrpg.setting.SettingObject? = null
+
+    @ManyToOne
+    var template: org.fg.ttrpg.setting.Template? = null
+
+    var overrideMode: String? = null
+
+    /** JSON payload storing object data */
+    var payload: String? = null
 }

--- a/src/main/kotlin/org/fg/ttrpg/campaign/resource/CampaignResource.kt
+++ b/src/main/kotlin/org/fg/ttrpg/campaign/resource/CampaignResource.kt
@@ -43,11 +43,14 @@ class CampaignResource @Inject constructor(
     ): CampaignObjectDTO {
         service.findById(id) ?: throw NotFoundException()
         val obj = objectRepo.findById(oid) ?: throw NotFoundException()
-        val merged = merge.merge(mapper.writeValueAsString(obj), patch)
+        val original = obj.payload ?: "{}"
+        val merged = merge.merge(original, patch)
         val node = mapper.readTree(merged)
-        validator.validate(obj.settingObject!!.id!!, node)
-        obj.name = node.get("name")?.asText() ?: obj.name
-        obj.description = node.get("description")?.asText()
+        val templateId = obj.template?.id ?: obj.settingObject?.id
+        if (templateId != null) {
+            validator.validate(templateId, node)
+        }
+        obj.payload = merged
         return obj.toDto()
     }
 }

--- a/src/main/resources/db/changelog/1-init.sql
+++ b/src/main/resources/db/changelog/1-init.sql
@@ -52,5 +52,8 @@ CREATE TABLE campaign_object (
     name VARCHAR(255) NOT NULL,
     description TEXT,
     campaign_id UUID NOT NULL REFERENCES campaign(id),
-    setting_object_id UUID NOT NULL REFERENCES setting_object(id)
+    setting_object_id UUID NOT NULL REFERENCES setting_object(id),
+    template_id UUID REFERENCES template(id),
+    override_mode VARCHAR(32),
+    payload JSONB
 );


### PR DESCRIPTION
## Summary
- add template, override mode and payload fields to `CampaignObject`
- include columns for these fields in the initial SQL
- patch endpoint now merges changes into the stored payload

## Testing
- `./gradlew assemble --no-daemon`
- `./gradlew test --no-daemon` *(fails: PSQLException ConnectException)*

------
https://chatgpt.com/codex/tasks/task_e_6859386046a08325acb33002c7284c3e