### PR TITLE
Add template filtering options

### DIFF
--- a/src/main/kotlin/org/fg/ttrpg/setting/TemplateRepository.kt
+++ b/src/main/kotlin/org/fg/ttrpg/setting/TemplateRepository.kt
@@ -5,4 +5,10 @@ import jakarta.enterprise.context.ApplicationScoped
 import java.util.UUID
 
 @ApplicationScoped
-class TemplateRepository : PanacheRepositoryBase<Template, UUID>
+class TemplateRepository : PanacheRepositoryBase<Template, UUID> {
+    fun listByGenre(genre: String) =
+        list("setting.genres.name", genre)
+
+    fun listByType(type: String) =
+        list("name", type)
+}

--- a/src/main/kotlin/org/fg/ttrpg/setting/resource/TemplateResource.kt
+++ b/src/main/kotlin/org/fg/ttrpg/setting/resource/TemplateResource.kt
@@ -17,11 +17,29 @@ class TemplateResource @Inject constructor(
     private val templates: TemplateRepository
 ) {
     @GET
-    fun list(@QueryParam("settingId") settingId: UUID?): List<TemplateDTO> {
-        val list = if (settingId != null) {
-            templates.list("setting.id", settingId)
-        } else {
+    fun list(
+        @QueryParam("settingId") settingId: UUID?,
+        @QueryParam("genre") genre: String?,
+        @QueryParam("type") type: String?
+    ): List<TemplateDTO> {
+        val filters = mutableListOf<String>()
+        val params = mutableListOf<Any>()
+        if (settingId != null) {
+            filters.add("setting.id = ?${'$'}{filters.size + 1}")
+            params.add(settingId)
+        }
+        if (genre != null) {
+            filters.add("setting.genres.name = ?${'$'}{filters.size + 1}")
+            params.add(genre)
+        }
+        if (type != null) {
+            filters.add("name = ?${'$'}{filters.size + 1}")
+            params.add(type)
+        }
+        val list = if (filters.isEmpty()) {
             templates.listAll()
+        } else {
+            templates.list(filters.joinToString(" and "), *params.toTypedArray())
         }
         return list.map { it.toDto() }
     }

--- a/src/test/kotlin/org/fg/ttrpg/repository/RepositoryIT.kt
+++ b/src/test/kotlin/org/fg/ttrpg/repository/RepositoryIT.kt
@@ -90,6 +90,8 @@ class RepositoryIT {
         genreRepo.count() shouldBe 1
         settingRepo.count() shouldBe 1
         templateRepo.count() shouldBe 1
+        templateRepo.listByGenre("fantasy").size shouldBe 1
+        templateRepo.listByType("template").size shouldBe 1
         settingObjectRepo.count() shouldBe 1
         campaignRepo.count() shouldBe 1
         campaignObjectRepo.count() shouldBe 1


### PR DESCRIPTION
## Summary
- allow filtering templates by genre and type
- expose helper methods in the repository
- check new queries in integration tests

## Testing
- `./gradlew test --no-daemon` *(fails: Connection refused to PostgreSQL)*

------
https://chatgpt.com/codex/tasks/task_e_685938635a888325acc2bbf585754155