### PR TITLE
Update Template to reference Genre

### DIFF
--- a/src/main/kotlin/org/fg/ttrpg/common/dto/TemplateDTO.kt
+++ b/src/main/kotlin/org/fg/ttrpg/common/dto/TemplateDTO.kt
@@ -6,6 +6,7 @@ data class TemplateDTO(
     val id: UUID?,
     val name: String,
     val description: String? = null,
-    val schema: String? = null,
-    val settingId: UUID
+    val type: String,
+    val jsonSchema: String? = null,
+    val genreId: UUID
 )

--- a/src/main/kotlin/org/fg/ttrpg/infra/validation/DatabaseTemplateSchemaRepository.kt
+++ b/src/main/kotlin/org/fg/ttrpg/infra/validation/DatabaseTemplateSchemaRepository.kt
@@ -10,5 +10,5 @@ class DatabaseTemplateSchemaRepository @Inject constructor(
     private val templates: TemplateRepository
 ) : TemplateSchemaRepository {
     override fun findSchema(templateId: UUID): String? =
-        templates.findById(templateId)?.schema
+        templates.findById(templateId)?.jsonSchema
 }

--- a/src/main/kotlin/org/fg/ttrpg/setting/Setting.kt
+++ b/src/main/kotlin/org/fg/ttrpg/setting/Setting.kt
@@ -18,8 +18,5 @@ class Setting  {
     var genres: MutableList<org.fg.ttrpg.genre.Genre> = mutableListOf()
 
     @OneToMany(mappedBy = "setting")
-    var templates: MutableList<Template> = mutableListOf()
-
-    @OneToMany(mappedBy = "setting")
     var objects: MutableList<SettingObject> = mutableListOf()
 }

--- a/src/main/kotlin/org/fg/ttrpg/setting/Template.kt
+++ b/src/main/kotlin/org/fg/ttrpg/setting/Template.kt
@@ -13,9 +13,12 @@ class Template  {
     var name: String? = null
     var description: String? = null
 
+    /** Type of objects described by this template (e.g. "npc", "item") */
+    var type: String? = null
+
     /** JSON schema describing objects of this template */
-    var schema: String? = null
+    var jsonSchema: String? = null
 
     @ManyToOne
-    var setting: Setting? = null
+    var genre: org.fg.ttrpg.genre.Genre? = null
 }

--- a/src/main/kotlin/org/fg/ttrpg/setting/TemplateRepository.kt
+++ b/src/main/kotlin/org/fg/ttrpg/setting/TemplateRepository.kt
@@ -5,4 +5,7 @@ import jakarta.enterprise.context.ApplicationScoped
 import java.util.UUID
 
 @ApplicationScoped
-class TemplateRepository : PanacheRepositoryBase<Template, UUID>
+class TemplateRepository : PanacheRepositoryBase<Template, UUID> {
+    fun listByGenreAndType(genreId: UUID, type: String): List<Template> =
+        list("genre.id = ?1 and type = ?2", genreId, type)
+}

--- a/src/main/kotlin/org/fg/ttrpg/setting/resource/TemplateResource.kt
+++ b/src/main/kotlin/org/fg/ttrpg/setting/resource/TemplateResource.kt
@@ -17,9 +17,12 @@ class TemplateResource @Inject constructor(
     private val templates: TemplateRepository
 ) {
     @GET
-    fun list(@QueryParam("settingId") settingId: UUID?): List<TemplateDTO> {
-        val list = if (settingId != null) {
-            templates.list("setting.id", settingId)
+    fun list(
+        @QueryParam("genre") genreId: UUID?,
+        @QueryParam("type") type: String?
+    ): List<TemplateDTO> {
+        val list = if (genreId != null && type != null) {
+            templates.listByGenreAndType(genreId, type)
         } else {
             templates.listAll()
         }
@@ -28,4 +31,11 @@ class TemplateResource @Inject constructor(
 }
 
 private fun Template.toDto() =
-    TemplateDTO(id, name ?: "", description, schema, setting?.id ?: error("Setting is null"))
+    TemplateDTO(
+        id,
+        name ?: "",
+        description,
+        type ?: "",
+        jsonSchema,
+        genre?.id ?: error("Genre is null")
+    )

--- a/src/main/resources/db/changelog/1-init.sql
+++ b/src/main/resources/db/changelog/1-init.sql
@@ -28,10 +28,11 @@ CREATE TABLE template (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     name VARCHAR(255) NOT NULL,
     description TEXT,
-    schema JSONB,
-    setting_id UUID NOT NULL REFERENCES setting(id)
+    type VARCHAR(255) NOT NULL,
+    json_schema JSONB,
+    genre_id UUID NOT NULL REFERENCES genre(id)
 );
-CREATE INDEX template_schema_gin_idx ON template USING GIN (schema);
+CREATE INDEX template_json_schema_gin_idx ON template USING GIN (json_schema);
 
 CREATE TABLE setting_object (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/src/test/kotlin/org/fg/ttrpg/repository/RepositoryIT.kt
+++ b/src/test/kotlin/org/fg/ttrpg/repository/RepositoryIT.kt
@@ -59,7 +59,9 @@ class RepositoryIT {
         val template = Template().apply {
             id = UUID.randomUUID()
             name = "template"
-            this.setting = setting
+            type = "npc"
+            jsonSchema = "{}"
+            this.genre = genre
         }
         templateRepo.persist(template)
 


### PR DESCRIPTION
## Summary
- reference `Genre` from `Template`
- add `type` and `jsonSchema` fields
- update DDL for new `template` schema
- query templates by genre and type via new API
- adjust repository integration test

## Testing
- `./gradlew test --no-daemon` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6859385d92f08325a9acffdf6a46a9e1