### PR TITLE
Add code & timestamps; rename name to title

### DIFF
--- a/src/main/kotlin/org/fg/ttrpg/campaign/Campaign.kt
+++ b/src/main/kotlin/org/fg/ttrpg/campaign/Campaign.kt
@@ -1,16 +1,22 @@
 package org.fg.ttrpg.campaign
 
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
+import java.time.Instant
 import java.util.UUID
 
 @Entity
 class Campaign  {
     @Id
     var id: UUID? = null
-    var name: String? = null
+    @Column(name = "name")
+    var title: String? = null
+
+    @Column(name = "started_on")
+    var startedOn: Instant? = null
 
     @ManyToOne
     var gm: org.fg.ttrpg.account.GM? = null

--- a/src/main/kotlin/org/fg/ttrpg/campaign/CampaignObject.kt
+++ b/src/main/kotlin/org/fg/ttrpg/campaign/CampaignObject.kt
@@ -1,15 +1,18 @@
 package org.fg.ttrpg.campaign
 
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.ManyToOne
+import java.time.Instant
 import java.util.UUID
 
 @Entity
 class CampaignObject {
     @Id
     var id: UUID? = null
-    var name: String? = null
+    @Column(name = "name")
+    var title: String? = null
     var description: String? = null
 
     @ManyToOne
@@ -25,6 +28,9 @@ class CampaignObject {
 
     /** JSON payload storing object data */
     var payload: String? = null
+
+    @Column(name = "created_at")
+    var createdAt: Instant? = null
 
     @ManyToOne
     var gm: org.fg.ttrpg.account.GM? = null

--- a/src/main/kotlin/org/fg/ttrpg/campaign/resource/CampaignResource.kt
+++ b/src/main/kotlin/org/fg/ttrpg/campaign/resource/CampaignResource.kt
@@ -58,6 +58,6 @@ class CampaignResource @Inject constructor(
     }
 }
 
-private fun Campaign.toDto() = CampaignDTO(id, name ?: "", gm?.id ?: error("GM is null"), setting?.id ?: error("Setting is null"))
+private fun Campaign.toDto() = CampaignDTO(id, title ?: "", gm?.id ?: error("GM is null"), setting?.id ?: error("Setting is null"))
 private fun CampaignObject.toDto() =
-    CampaignObjectDTO(id, name ?: "", description, campaign?.id ?: error("Campaign is null"), settingObject?.id ?: error("SettingObject is null"))
+    CampaignObjectDTO(id, title ?: "", description, campaign?.id ?: error("Campaign is null"), settingObject?.id ?: error("SettingObject is null"))

--- a/src/main/kotlin/org/fg/ttrpg/common/dto/CampaignDTO.kt
+++ b/src/main/kotlin/org/fg/ttrpg/common/dto/CampaignDTO.kt
@@ -4,7 +4,7 @@ import java.util.UUID
 
 data class CampaignDTO(
     val id: UUID?,
-    val name: String,
+    val title: String,
     val gmId: UUID,
     val settingId: UUID
 )

--- a/src/main/kotlin/org/fg/ttrpg/common/dto/CampaignObjectDTO.kt
+++ b/src/main/kotlin/org/fg/ttrpg/common/dto/CampaignObjectDTO.kt
@@ -4,7 +4,7 @@ import java.util.UUID
 
 data class CampaignObjectDTO(
     val id: UUID?,
-    val name: String,
+    val title: String,
     val description: String? = null,
     val campaignId: UUID,
     val settingObjectId: UUID

--- a/src/main/kotlin/org/fg/ttrpg/common/dto/SettingDTO.kt
+++ b/src/main/kotlin/org/fg/ttrpg/common/dto/SettingDTO.kt
@@ -4,7 +4,7 @@ import java.util.UUID
 
 data class SettingDTO(
     val id: UUID?,
-    val name: String,
+    val title: String,
     val description: String? = null,
     val gmId: UUID
 )

--- a/src/main/kotlin/org/fg/ttrpg/common/dto/SettingObjectDTO.kt
+++ b/src/main/kotlin/org/fg/ttrpg/common/dto/SettingObjectDTO.kt
@@ -5,7 +5,7 @@ import java.util.UUID
 data class SettingObjectDTO(
     val id: UUID?,
     val slug: String,
-    val name: String,
+    val title: String,
     val description: String? = null,
     val payload: String? = null,
     val tags: List<String> = emptyList(),

--- a/src/main/kotlin/org/fg/ttrpg/common/dto/TemplateDTO.kt
+++ b/src/main/kotlin/org/fg/ttrpg/common/dto/TemplateDTO.kt
@@ -4,7 +4,7 @@ import java.util.UUID
 
 data class TemplateDTO(
     val id: UUID?,
-    val name: String,
+    val title: String,
     val description: String? = null,
     val type: String,
     val jsonSchema: String? = null,

--- a/src/main/kotlin/org/fg/ttrpg/genre/Genre.kt
+++ b/src/main/kotlin/org/fg/ttrpg/genre/Genre.kt
@@ -1,5 +1,6 @@
 package org.fg.ttrpg.genre
 
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.ManyToOne
@@ -9,7 +10,11 @@ import java.util.UUID
 class Genre  {
     @Id
     var id: UUID? = null
-    var name: String? = null
+    @Column(name = "name")
+    var title: String? = null
+
+    @Column(nullable = false, unique = true)
+    var code: String? = null
 
     @ManyToOne
     var setting: org.fg.ttrpg.setting.Setting? = null

--- a/src/main/kotlin/org/fg/ttrpg/setting/Setting.kt
+++ b/src/main/kotlin/org/fg/ttrpg/setting/Setting.kt
@@ -1,18 +1,24 @@
 package org.fg.ttrpg.setting
 
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.ManyToMany
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
+import java.time.Instant
 import java.util.UUID
 
 @Entity
 class Setting  {
     @Id
     var id: UUID? = null
-    var name: String? = null
+    @Column(name = "name")
+    var title: String? = null
     var description: String? = null
+
+    @Column(name = "created_at")
+    var createdAt: Instant? = null
 
     @ManyToOne
     var gm: org.fg.ttrpg.account.GM? = null

--- a/src/main/kotlin/org/fg/ttrpg/setting/SettingObject.kt
+++ b/src/main/kotlin/org/fg/ttrpg/setting/SettingObject.kt
@@ -1,6 +1,7 @@
 package org.fg.ttrpg.setting
 
 import jakarta.persistence.*
+import java.time.Instant
 import java.util.UUID
 
 @Entity
@@ -8,11 +9,15 @@ class SettingObject  {
     @Id
     var id: UUID? = null
     var slug: String? = null
-    var name: String? = null
+    @Column(name = "name")
+    var title: String? = null
     var description: String? = null
     /** Arbitrary JSON payload describing this object */
     @Column(columnDefinition = "jsonb")
     var payload: String? = null
+
+    @Column(name = "created_at")
+    var createdAt: Instant? = null
 
     @ElementCollection
     @CollectionTable(name = "setting_object_tags", joinColumns = [JoinColumn(name = "setting_object_id")])

--- a/src/main/kotlin/org/fg/ttrpg/setting/Template.kt
+++ b/src/main/kotlin/org/fg/ttrpg/setting/Template.kt
@@ -1,16 +1,22 @@
 package org.fg.ttrpg.setting
 
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.ManyToOne
+import java.time.Instant
 import java.util.UUID
 
 @Entity
 class Template  {
     @Id
     var id: UUID? = null
-    var name: String? = null
+    @Column(name = "name")
+    var title: String? = null
     var description: String? = null
+
+    @Column(name = "created_at")
+    var createdAt: Instant? = null
 
     /** Type of objects described by this template (e.g. "npc", "item") */
     var type: String? = null

--- a/src/main/kotlin/org/fg/ttrpg/setting/TemplateRepository.kt
+++ b/src/main/kotlin/org/fg/ttrpg/setting/TemplateRepository.kt
@@ -12,10 +12,10 @@ class TemplateRepository : PanacheRepositoryBase<Template, UUID> {
         list("setting.id=?1 and gm.id=?2", settingId, gmId)
 
     fun listByGenre(genre: String) =
-        list("setting.genres.name", genre)
+        list("setting.genres.title", genre)
 
     fun listByType(type: String) =
-        list("name", type)
+        list("title", type)
 
     fun listByGenreAndType(genreId: UUID, type: String) : List<Template> =
         list("genre.id = ?1 and type = ?2", genreId, type)

--- a/src/main/kotlin/org/fg/ttrpg/setting/resource/SettingResource.kt
+++ b/src/main/kotlin/org/fg/ttrpg/setting/resource/SettingResource.kt
@@ -32,7 +32,7 @@ class SettingResource @Inject constructor(
     fun create(dto: SettingDTO): SettingDTO {
         val gm = gmRepo.findById(gmId()) ?: throw NotFoundException()
         val entity = Setting().apply {
-            name = dto.name
+            title = dto.title
             description = dto.description
             this.gm = gm
         }
@@ -48,7 +48,7 @@ class SettingResource @Inject constructor(
         val template = dto.templateId?.let { templateRepo.findById(it) } ?: dto.templateId?.let { throw NotFoundException() }
         val obj = SettingObject().apply {
             slug = dto.slug
-            name = dto.name
+            title = dto.title
             description = dto.description
             payload = dto.payload
             tags = dto.tags.toMutableList()
@@ -62,13 +62,13 @@ class SettingResource @Inject constructor(
 }
 
 private fun Setting.toDto() =
-    SettingDTO(id, name ?: "", description, gm?.id ?: error("GM is null"))
+    SettingDTO(id, title ?: "", description, gm?.id ?: error("GM is null"))
 
 private fun SettingObject.toDto() =
     SettingObjectDTO(
         id,
         slug ?: "",
-        name ?: "",
+        title ?: "",
         description,
         payload,
         tags.toList(),

--- a/src/main/kotlin/org/fg/ttrpg/setting/resource/TemplateResource.kt
+++ b/src/main/kotlin/org/fg/ttrpg/setting/resource/TemplateResource.kt
@@ -39,7 +39,7 @@ class TemplateResource @Inject constructor(
 private fun Template.toDto() =
     TemplateDTO(
         id,
-        name ?: "",
+        title ?: "",
         description,
         type ?: "",
         jsonSchema,

--- a/src/main/resources/db/changelog/1-init.sql
+++ b/src/main/resources/db/changelog/1-init.sql
@@ -11,12 +11,14 @@ CREATE TABLE setting (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     name VARCHAR(255) NOT NULL,
     description TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT now(),
     gm_id UUID NOT NULL REFERENCES gm(id)
 );
 
 CREATE TABLE genre (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     name VARCHAR(255) NOT NULL,
+    code VARCHAR(255) NOT NULL UNIQUE,
     setting_id UUID NOT NULL REFERENCES setting(id)
 );
 
@@ -24,6 +26,7 @@ CREATE TABLE template (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     name VARCHAR(255) NOT NULL,
     description TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT now(),
     type VARCHAR(255) NOT NULL,
     json_schema JSONB,
     genre_id UUID NOT NULL REFERENCES genre(id),
@@ -36,6 +39,7 @@ CREATE TABLE setting_object (
     slug VARCHAR(255) NOT NULL,
     name VARCHAR(255) NOT NULL,
     description TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT now(),
     payload JSONB,
     template_id UUID REFERENCES template(id),
     setting_id UUID NOT NULL REFERENCES setting(id),
@@ -51,6 +55,7 @@ CREATE TABLE setting_object_tags (
 CREATE TABLE campaign (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     name VARCHAR(255) NOT NULL,
+    started_on TIMESTAMP NOT NULL DEFAULT now(),
     gm_id UUID NOT NULL REFERENCES gm(id),
     setting_id UUID NOT NULL REFERENCES setting(id)
 );
@@ -59,6 +64,7 @@ CREATE TABLE campaign_object (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     name VARCHAR(255) NOT NULL,
     description TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT now(),
     campaign_id UUID NOT NULL REFERENCES campaign(id),
     setting_object_id UUID NOT NULL REFERENCES setting_object(id),
     gm_id UUID NOT NULL REFERENCES gm(id),

--- a/src/test/kotlin/org/fg/ttrpg/repository/RepositoryIT.kt
+++ b/src/test/kotlin/org/fg/ttrpg/repository/RepositoryIT.kt
@@ -30,7 +30,7 @@ class RepositoryIT {
 
         val setting = Setting().apply {
             id = UUID.randomUUID()
-            name = "world"
+            title = "world"
             this.gm = gm
         }
         settingRepo.persist(setting)


### PR DESCRIPTION
## Summary
- add `code` and `createdAt/startedOn` columns
- rename `name` to `title` across entities & DTOs
- update JPA mappings and queries
- adjust database initialization script

## Testing
- `./gradlew test --no-daemon` *(fails: PSQLException Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68594bc404a883259da26cf5811ee230