### PR TITLE
Update CI to run tests with scan and build docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Cache Gradle wrapper
+        uses: actions/cache@v4
+        with:
+          path: ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: ${{ runner.os }}-gradle-wrapper
+
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
@@ -22,5 +29,11 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      - name: Run Integration Tests
+        run: ./gradlew test --scan
+
       - name: Build
-        run: ./gradlew build
+        run: ./gradlew build --scan
+
+      - name: Build Docker image
+        run: docker build -f src/main/docker/Dockerfile.jvm -t codex-jvm .


### PR DESCRIPTION
## Summary
- run tests with `--scan`
- build with `--scan`
- cache the Gradle wrapper
- attempt Docker image build using the JVM Dockerfile

## Testing
- `./gradlew test --scan` *(fails: IllegalStateException at DockerClientProviderStrategy)*
- `docker build -f src/main/docker/Dockerfile.jvm -t codex-jvm .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68596641bf18832594edb842ec28615c