### PR TITLE
Configure jOOQ for Quarkus

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,3 +8,5 @@ quarkus:
   liquibase:
     change-log: db/changelog/db.changelog-master.yaml
     migrate-at-start: true
+  jooq:
+    dialect: POSTGRES

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -2,4 +2,5 @@ quarkus.datasource.db-kind=h2
 quarkus.datasource.jdbc.url=jdbc:h2:mem:test;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
 quarkus.datasource.username=sa
 quarkus.datasource.password=sa
-quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.liquibase.migrate-at-start=true
+quarkus.jooq.dialect=H2


### PR DESCRIPTION
## Summary
- configure jOOQ dialect in main config
- set liquibase + jOOQ properties for tests

## Testing
- `./gradlew test --no-daemon` *(fails: Could not find io.quarkus:quarkus-jooq)*

------
https://chatgpt.com/codex/tasks/task_e_6859a4d6bdf08325a3d6eaa7a11e6333