### PR TITLE
Fix test for jOOQ SettingRepository

### DIFF
--- a/src/test/kotlin/org/fg/ttrpg/SettingResourceIT.kt
+++ b/src/test/kotlin/org/fg/ttrpg/SettingResourceIT.kt
@@ -146,7 +146,7 @@ class SettingResourceIT {
 
     @TestTransaction
     fun verifySettings(gmId: UUID, expected: Int) {
-        val count = settingRepo.list("gm.id", gmId).size
+        val count = settingRepo.listByGm(gmId).size
         org.junit.jupiter.api.Assertions.assertEquals(expected, count)
     }
 }


### PR DESCRIPTION
## Summary
- update SettingResourceIT assertion to use `listByGm`

## Testing
- `./gradlew test --no-daemon --console=plain` *(fails: Could not find io.quarkus:quarkus-jooq:)*

------
https://chatgpt.com/codex/tasks/task_e_6859a67425e0832594f4583a442bb0d8