### PR TITLE
Rename name column to title

### DIFF
--- a/src/main/kotlin/org/fg/ttrpg/campaign/CampaignObjectRepository.kt
+++ b/src/main/kotlin/org/fg/ttrpg/campaign/CampaignObjectRepository.kt
@@ -17,7 +17,7 @@ class CampaignObjectRepository @Inject constructor(private val jdbi: Jdbi) {
 
     fun listByCampaignAndGm(campaignId: UUID, gmId: UUID): List<CampaignObject> =
         jdbi.withHandle<List<CampaignObject>, Exception> { handle ->
-            handle.createQuery("SELECT id, name, description, campaign_id, setting_object_id, gm_id, template_id, override_mode, payload, created_at FROM campaign_object WHERE campaign_id = :campaignId AND gm_id = :gmId")
+            handle.createQuery("SELECT id, title, description, campaign_id, setting_object_id, gm_id, template_id, override_mode, payload, created_at FROM campaign_object WHERE campaign_id = :campaignId AND gm_id = :gmId")
                 .bind("campaignId", campaignId)
                 .bind("gmId", gmId)
                 .map(CampaignObjectMapper())
@@ -26,7 +26,7 @@ class CampaignObjectRepository @Inject constructor(private val jdbi: Jdbi) {
 
     fun findById(id: UUID): CampaignObject? =
         jdbi.withHandle<CampaignObject?, Exception> { handle ->
-            handle.createQuery("SELECT id, name, description, campaign_id, setting_object_id, gm_id, template_id, override_mode, payload, created_at FROM campaign_object WHERE id = :id")
+            handle.createQuery("SELECT id, title, description, campaign_id, setting_object_id, gm_id, template_id, override_mode, payload, created_at FROM campaign_object WHERE id = :id")
                 .bind("id", id)
                 .map(CampaignObjectMapper())
                 .findOne()
@@ -35,7 +35,7 @@ class CampaignObjectRepository @Inject constructor(private val jdbi: Jdbi) {
 
     fun findByIdForGm(id: UUID, gmId: UUID): CampaignObject? =
         jdbi.withHandle<CampaignObject?, Exception> { handle ->
-            handle.createQuery("SELECT id, name, description, campaign_id, setting_object_id, gm_id, template_id, override_mode, payload, created_at FROM campaign_object WHERE id = :id AND gm_id = :gmId")
+            handle.createQuery("SELECT id, title, description, campaign_id, setting_object_id, gm_id, template_id, override_mode, payload, created_at FROM campaign_object WHERE id = :id AND gm_id = :gmId")
                 .bind("id", id)
                 .bind("gmId", gmId)
                 .map(CampaignObjectMapper())
@@ -45,9 +45,9 @@ class CampaignObjectRepository @Inject constructor(private val jdbi: Jdbi) {
 
     fun persist(obj: CampaignObject) {
         jdbi.useHandle<Exception> { handle ->
-            handle.createUpdate("INSERT INTO campaign_object (id, name, description, campaign_id, setting_object_id, gm_id, template_id, override_mode, payload, created_at) VALUES (:id, :name, :description, :campaignId, :settingObjectId, :gmId, :templateId, :overrideMode, :payload::jsonb, :createdAt)")
+            handle.createUpdate("INSERT INTO campaign_object (id, title, description, campaign_id, setting_object_id, gm_id, template_id, override_mode, payload, created_at) VALUES (:id, :title, :description, :campaignId, :settingObjectId, :gmId, :templateId, :overrideMode, :payload::jsonb, :createdAt)")
                 .bind("id", obj.id)
-                .bind("name", obj.title)
+                .bind("title", obj.title)
                 .bind("description", obj.description)
                 .bind("campaignId", obj.campaign?.id)
                 .bind("settingObjectId", obj.settingObject?.id)
@@ -73,7 +73,7 @@ class CampaignObjectRepository @Inject constructor(private val jdbi: Jdbi) {
         jdbi.useHandle<Exception> { handle ->
             handle.createUpdate("""
                 UPDATE campaign_object SET
-                    name = :name,
+                    title = :title,
                     description = :description,
                     campaign_id = :campaignId,
                     setting_object_id = :settingObjectId,
@@ -84,7 +84,7 @@ class CampaignObjectRepository @Inject constructor(private val jdbi: Jdbi) {
                 WHERE id = :id
             """)
                 .bind("id", obj.id)
-                .bind("name", obj.title)
+                .bind("title", obj.title)
                 .bind("description", obj.description)
                 .bind("campaignId", obj.campaign?.id)
                 .bind("settingObjectId", obj.settingObject?.id)
@@ -99,7 +99,7 @@ class CampaignObjectRepository @Inject constructor(private val jdbi: Jdbi) {
     private class CampaignObjectMapper : RowMapper<CampaignObject> {
         override fun map(rs: ResultSet, ctx: StatementContext): CampaignObject = CampaignObject().apply {
             id = rs.getObject("id", UUID::class.java)
-            title = rs.getString("name")
+            title = rs.getString("title")
             description = rs.getString("description")
             campaign = Campaign().apply { id = rs.getObject("campaign_id", UUID::class.java) }
             settingObject = SettingObject().apply { id = rs.getObject("setting_object_id", UUID::class.java) }

--- a/src/main/kotlin/org/fg/ttrpg/campaign/CampaignRepository.kt
+++ b/src/main/kotlin/org/fg/ttrpg/campaign/CampaignRepository.kt
@@ -16,7 +16,7 @@ class CampaignRepository @Inject constructor(private val jdbi: Jdbi) {
 
     fun listByGm(gmId: UUID): List<Campaign> =
         jdbi.withHandle<List<Campaign>, Exception> { handle ->
-            handle.createQuery("SELECT id, name, started_on, gm_id, setting_id FROM campaign WHERE gm_id = :gmId")
+            handle.createQuery("SELECT id, title, started_on, gm_id, setting_id FROM campaign WHERE gm_id = :gmId")
                 .bind("gmId", gmId)
                 .map(CampaignMapper())
                 .list()
@@ -24,7 +24,7 @@ class CampaignRepository @Inject constructor(private val jdbi: Jdbi) {
 
     fun findById(id: UUID): Campaign? =
         jdbi.withHandle<Campaign?, Exception> { handle ->
-            handle.createQuery("SELECT id, name, started_on, gm_id, setting_id FROM campaign WHERE id = :id")
+            handle.createQuery("SELECT id, title, started_on, gm_id, setting_id FROM campaign WHERE id = :id")
                 .bind("id", id)
                 .map(CampaignMapper())
                 .findOne()
@@ -33,7 +33,7 @@ class CampaignRepository @Inject constructor(private val jdbi: Jdbi) {
 
     fun findByIdForGm(id: UUID, gmId: UUID): Campaign? =
         jdbi.withHandle<Campaign?, Exception> { handle ->
-            handle.createQuery("SELECT id, name, started_on, gm_id, setting_id FROM campaign WHERE id = :id AND gm_id = :gmId")
+            handle.createQuery("SELECT id, title, started_on, gm_id, setting_id FROM campaign WHERE id = :id AND gm_id = :gmId")
                 .bind("id", id)
                 .bind("gmId", gmId)
                 .map(CampaignMapper())
@@ -43,9 +43,9 @@ class CampaignRepository @Inject constructor(private val jdbi: Jdbi) {
 
     fun persist(campaign: Campaign) {
         jdbi.useHandle<Exception> { handle ->
-            handle.createUpdate("INSERT INTO campaign (id, name, started_on, gm_id, setting_id) VALUES (:id, :name, :startedOn, :gmId, :settingId)")
+            handle.createUpdate("INSERT INTO campaign (id, title, started_on, gm_id, setting_id) VALUES (:id, :title, :startedOn, :gmId, :settingId)")
                 .bind("id", campaign.id)
-                .bind("name", campaign.title)
+                .bind("title", campaign.title)
                 .bind("startedOn", campaign.startedOn)
                 .bind("gmId", campaign.gm?.id)
                 .bind("settingId", campaign.setting?.id)
@@ -56,7 +56,7 @@ class CampaignRepository @Inject constructor(private val jdbi: Jdbi) {
     private class CampaignMapper : RowMapper<Campaign> {
         override fun map(rs: ResultSet, ctx: StatementContext): Campaign = Campaign().apply {
             id = rs.getObject("id", UUID::class.java)
-            title = rs.getString("name")
+            title = rs.getString("title")
             startedOn = rs.getTimestamp("started_on")?.toInstant()
             gm = GM().apply { id = rs.getObject("gm_id", UUID::class.java) }
             setting = Setting().apply { id = rs.getObject("setting_id", UUID::class.java) }

--- a/src/main/kotlin/org/fg/ttrpg/genre/GenreRepository.kt
+++ b/src/main/kotlin/org/fg/ttrpg/genre/GenreRepository.kt
@@ -8,9 +8,9 @@ import org.jdbi.v3.core.Jdbi
 class GenreRepository @Inject constructor(private val jdbi: Jdbi) {
     fun insert(genre: Genre) {
         jdbi.useHandle<Nothing> { handle ->
-            handle.createUpdate("INSERT INTO genre (id, name, code, setting_id) VALUES (:id, :name, :code, :settingId)")
+            handle.createUpdate("INSERT INTO genre (id, title, code, setting_id) VALUES (:id, :title, :code, :settingId)")
                 .bind("id", genre.id)
-                .bind("name", genre.title)
+                .bind("title", genre.title)
                 .bind("code", genre.code)
                 .bind("settingId", genre.setting?.id)
                 .execute()

--- a/src/main/kotlin/org/fg/ttrpg/setting/SettingObjectRepository.kt
+++ b/src/main/kotlin/org/fg/ttrpg/setting/SettingObjectRepository.kt
@@ -15,7 +15,7 @@ class SettingObjectRepository @Inject constructor(private val jdbi: Jdbi) {
 
     fun listBySettingAndGm(settingId: UUID, gmId: UUID): List<SettingObject> =
         jdbi.withHandle<List<SettingObject>, Exception> { handle ->
-            handle.createQuery("SELECT id, slug, name, description, payload, setting_id, template_id, gm_id, created_at FROM setting_object WHERE setting_id = :settingId AND gm_id = :gmId")
+            handle.createQuery("SELECT id, slug, title, description, payload, setting_id, template_id, gm_id, created_at FROM setting_object WHERE setting_id = :settingId AND gm_id = :gmId")
                 .bind("settingId", settingId)
                 .bind("gmId", gmId)
                 .map(SettingObjectMapper())
@@ -24,7 +24,7 @@ class SettingObjectRepository @Inject constructor(private val jdbi: Jdbi) {
 
     fun listByGm(gmId: UUID): List<SettingObject> =
         jdbi.withHandle<List<SettingObject>, Exception> { handle ->
-            handle.createQuery("SELECT id, slug, name, description, payload, setting_id, template_id, gm_id, created_at FROM setting_object WHERE gm_id = :gmId")
+            handle.createQuery("SELECT id, slug, title, description, payload, setting_id, template_id, gm_id, created_at FROM setting_object WHERE gm_id = :gmId")
                 .bind("gmId", gmId)
                 .map(SettingObjectMapper())
                 .list()
@@ -32,7 +32,7 @@ class SettingObjectRepository @Inject constructor(private val jdbi: Jdbi) {
 
     fun findById(id: UUID): SettingObject? =
         jdbi.withHandle<SettingObject?, Exception> { handle ->
-            handle.createQuery("SELECT id, slug, name, description, payload, setting_id, template_id, gm_id, created_at FROM setting_object WHERE id = :id")
+            handle.createQuery("SELECT id, slug, title, description, payload, setting_id, template_id, gm_id, created_at FROM setting_object WHERE id = :id")
                 .bind("id", id)
                 .map(SettingObjectMapper())
                 .findOne()
@@ -41,7 +41,7 @@ class SettingObjectRepository @Inject constructor(private val jdbi: Jdbi) {
 
     fun findByIdForGm(id: UUID, gmId: UUID): SettingObject? =
         jdbi.withHandle<SettingObject?, Exception> { handle ->
-            handle.createQuery("SELECT id, slug, name, description, payload, setting_id, template_id, gm_id, created_at FROM setting_object WHERE id = :id AND gm_id = :gmId")
+            handle.createQuery("SELECT id, slug, title, description, payload, setting_id, template_id, gm_id, created_at FROM setting_object WHERE id = :id AND gm_id = :gmId")
                 .bind("id", id)
                 .bind("gmId", gmId)
                 .map(SettingObjectMapper())
@@ -57,10 +57,10 @@ class SettingObjectRepository @Inject constructor(private val jdbi: Jdbi) {
             obj.createdAt = java.time.Instant.now()
         }
         jdbi.useHandle<Exception> { handle ->
-            handle.createUpdate("INSERT INTO setting_object (id, slug, name, description, payload, setting_id, template_id, gm_id, created_at) VALUES (:id, :slug, :name, :description, :payload::jsonb, :settingId, :templateId, :gmId, :createdAt)")
+            handle.createUpdate("INSERT INTO setting_object (id, slug, title, description, payload, setting_id, template_id, gm_id, created_at) VALUES (:id, :slug, :title, :description, :payload::jsonb, :settingId, :templateId, :gmId, :createdAt)")
                 .bind("id", obj.id)
                 .bind("slug", obj.slug)
-                .bind("name", obj.title)
+                .bind("title", obj.title)
                 .bind("description", obj.description)
                 .bind("payload", obj.payload)
                 .bind("settingId", obj.setting?.id)
@@ -76,7 +76,7 @@ class SettingObjectRepository @Inject constructor(private val jdbi: Jdbi) {
         override fun map(rs: ResultSet, ctx: StatementContext): SettingObject = SettingObject().apply {
             id = rs.getObject("id", UUID::class.java)
             slug = rs.getString("slug")
-            title = rs.getString("name")
+            title = rs.getString("title")
             description = rs.getString("description")
             payload = rs.getString("payload")
             createdAt = rs.getTimestamp("created_at").toInstant()

--- a/src/main/kotlin/org/fg/ttrpg/setting/SettingRepository.kt
+++ b/src/main/kotlin/org/fg/ttrpg/setting/SettingRepository.kt
@@ -15,7 +15,7 @@ class SettingRepository @Inject constructor(private val jdbi: Jdbi) {
 
     fun listByGm(gmId: UUID): List<Setting> =
         jdbi.withHandle<List<Setting>, Exception> { handle ->
-            handle.createQuery("SELECT id, name, description, gm_id, created_at FROM setting WHERE gm_id = :gmId")
+            handle.createQuery("SELECT id, title, description, gm_id, created_at FROM setting WHERE gm_id = :gmId")
                 .bind("gmId", gmId)
                 .map(SettingMapper())
                 .list()
@@ -23,7 +23,7 @@ class SettingRepository @Inject constructor(private val jdbi: Jdbi) {
 
     fun findById(id: UUID): Setting? =
         jdbi.withHandle<Setting?, Exception> { handle ->
-            handle.createQuery("SELECT id, name, description, gm_id, created_at FROM setting WHERE id = :id")
+            handle.createQuery("SELECT id, title, description, gm_id, created_at FROM setting WHERE id = :id")
                 .bind("id", id)
                 .map(SettingMapper())
                 .findOne()
@@ -32,7 +32,7 @@ class SettingRepository @Inject constructor(private val jdbi: Jdbi) {
 
     fun findByIdForGm(id: UUID, gmId: UUID): Setting? =
         jdbi.withHandle<Setting?, Exception> { handle ->
-            handle.createQuery("SELECT id, name, description, gm_id, created_at FROM setting WHERE id = :id AND gm_id = :gmId")
+            handle.createQuery("SELECT id, title, description, gm_id, created_at FROM setting WHERE id = :id AND gm_id = :gmId")
                 .bind("id", id)
                 .bind("gmId", gmId)
                 .map(SettingMapper())
@@ -46,17 +46,17 @@ class SettingRepository @Inject constructor(private val jdbi: Jdbi) {
         }
         jdbi.useHandle<Exception> { handle ->
             if (setting.createdAt != null) {
-                handle.createUpdate("INSERT INTO setting (id, name, description, gm_id, created_at) VALUES (:id, :name, :description, :gmId, :createdAt)")
+                handle.createUpdate("INSERT INTO setting (id, title, description, gm_id, created_at) VALUES (:id, :title, :description, :gmId, :createdAt)")
                     .bind("id", setting.id)
-                    .bind("name", setting.title)
+                    .bind("title", setting.title)
                     .bind("description", setting.description)
                     .bind("gmId", setting.gm?.id)
                     .bind("createdAt", setting.createdAt)
                     .execute()
             } else {
-                handle.createUpdate("INSERT INTO setting (id, name, description, gm_id) VALUES (:id, :name, :description, :gmId)")
+                handle.createUpdate("INSERT INTO setting (id, title, description, gm_id) VALUES (:id, :title, :description, :gmId)")
                     .bind("id", setting.id)
-                    .bind("name", setting.title)
+                    .bind("title", setting.title)
                     .bind("description", setting.description)
                     .bind("gmId", setting.gm?.id)
                     .execute()
@@ -67,7 +67,7 @@ class SettingRepository @Inject constructor(private val jdbi: Jdbi) {
     private class SettingMapper : RowMapper<Setting> {
         override fun map(rs: ResultSet, ctx: StatementContext): Setting = Setting().apply {
             id = rs.getObject("id", UUID::class.java)
-            title = rs.getString("name")
+            title = rs.getString("title")
             description = rs.getString("description")
             createdAt = rs.getTimestamp("created_at").toInstant()
             gm = GM().apply { id = rs.getObject("gm_id", UUID::class.java) }

--- a/src/main/kotlin/org/fg/ttrpg/setting/TemplateRepository.kt
+++ b/src/main/kotlin/org/fg/ttrpg/setting/TemplateRepository.kt
@@ -16,7 +16,7 @@ class TemplateRepository @Inject constructor(private val jdbi: Jdbi) {
 
     fun listByGm(gmId: UUID): List<Template> =
         jdbi.withHandle<List<Template>, Exception> { handle ->
-            handle.createQuery("SELECT id, name, description, json_schema, type, gm_id, genre_id, created_at FROM template WHERE gm_id = :gmId")
+            handle.createQuery("SELECT id, title, description, json_schema, type, gm_id, genre_id, created_at FROM template WHERE gm_id = :gmId")
                 .bind("gmId", gmId)
                 .map(TemplateMapper())
                 .list()
@@ -24,7 +24,7 @@ class TemplateRepository @Inject constructor(private val jdbi: Jdbi) {
 
     fun findById(id: UUID): Template? =
         jdbi.withHandle<Template?, Exception> { handle ->
-            handle.createQuery("SELECT id, name, description, json_schema, type, gm_id, genre_id, created_at FROM template WHERE id = :id")
+            handle.createQuery("SELECT id, title, description, json_schema, type, gm_id, genre_id, created_at FROM template WHERE id = :id")
                 .bind("id", id)
                 .map(TemplateMapper())
                 .findOne()
@@ -33,7 +33,7 @@ class TemplateRepository @Inject constructor(private val jdbi: Jdbi) {
 
     fun findByIdForGm(id: UUID, gmId: UUID): Template? =
         jdbi.withHandle<Template?, Exception> { handle ->
-            handle.createQuery("SELECT id, name, description, json_schema, type, gm_id, genre_id, created_at FROM template WHERE id = :id AND gm_id = :gmId")
+            handle.createQuery("SELECT id, title, description, json_schema, type, gm_id, genre_id, created_at FROM template WHERE id = :id AND gm_id = :gmId")
                 .bind("id", id)
                 .bind("gmId", gmId)
                 .map(TemplateMapper())
@@ -43,7 +43,7 @@ class TemplateRepository @Inject constructor(private val jdbi: Jdbi) {
 
     fun listByGenre(genre: String): List<Template> =
         jdbi.withHandle<List<Template>, Exception> { handle ->
-            handle.createQuery("SELECT id, name, description, json_schema, type, gm_id, genre_id, created_at FROM template WHERE genre_id = :genreId")
+            handle.createQuery("SELECT id, title, description, json_schema, type, gm_id, genre_id, created_at FROM template WHERE genre_id = :genreId")
                 .bind("genreId", UUID.fromString(genre))
                 .map(TemplateMapper())
                 .list()
@@ -51,7 +51,7 @@ class TemplateRepository @Inject constructor(private val jdbi: Jdbi) {
 
     fun listByType(type: String): List<Template> =
         jdbi.withHandle<List<Template>, Exception> { handle ->
-            handle.createQuery("SELECT id, name, description, json_schema, type, gm_id, genre_id, created_at FROM template WHERE type = :type")
+            handle.createQuery("SELECT id, title, description, json_schema, type, gm_id, genre_id, created_at FROM template WHERE type = :type")
                 .bind("type", type)
                 .map(TemplateMapper())
                 .list()
@@ -63,9 +63,9 @@ class TemplateRepository @Inject constructor(private val jdbi: Jdbi) {
         require(!template.type.isNullOrBlank()) { "Template.type must not be null or blank" }
         jdbi.useHandle<Exception> { handle ->
             if (template.createdAt != null) {
-                handle.createUpdate("INSERT INTO template (id, name, description, json_schema, type, gm_id, genre_id, created_at) VALUES (:id, :name, :description, :jsonSchema::jsonb, :type, :gmId, :genreId, :createdAt)")
+                handle.createUpdate("INSERT INTO template (id, title, description, json_schema, type, gm_id, genre_id, created_at) VALUES (:id, :title, :description, :jsonSchema::jsonb, :type, :gmId, :genreId, :createdAt)")
                     .bind("id", template.id)
-                    .bind("name", template.title)
+                    .bind("title", template.title)
                     .bind("description", template.description)
                     .bind("jsonSchema", template.jsonSchema)
                     .bind("type", template.type)
@@ -74,9 +74,9 @@ class TemplateRepository @Inject constructor(private val jdbi: Jdbi) {
                     .bind("createdAt", template.createdAt)
                     .execute()
             } else {
-                handle.createUpdate("INSERT INTO template (id, name, description, json_schema, type, gm_id, genre_id) VALUES (:id, :name, :description, :jsonSchema::jsonb, :type, :gmId, :genreId)")
+                handle.createUpdate("INSERT INTO template (id, title, description, json_schema, type, gm_id, genre_id) VALUES (:id, :title, :description, :jsonSchema::jsonb, :type, :gmId, :genreId)")
                     .bind("id", template.id)
-                    .bind("name", template.title)
+                    .bind("title", template.title)
                     .bind("description", template.description)
                     .bind("jsonSchema", template.jsonSchema)
                     .bind("type", template.type)
@@ -90,7 +90,7 @@ class TemplateRepository @Inject constructor(private val jdbi: Jdbi) {
     private class TemplateMapper : RowMapper<Template> {
         override fun map(rs: ResultSet, ctx: StatementContext): Template = Template().apply {
             id = rs.getObject("id", UUID::class.java)
-            title = rs.getString("name")
+            title = rs.getString("title")
             description = rs.getString("description")
             jsonSchema = rs.getString("json_schema")
             type = rs.getString("type")

--- a/src/main/resources/db/changelog/1-init.sql
+++ b/src/main/resources/db/changelog/1-init.sql
@@ -9,7 +9,7 @@ CREATE TABLE gm (
 
 CREATE TABLE setting (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    name VARCHAR(255) NOT NULL,
+    title VARCHAR(255) NOT NULL,
     description TEXT,
     created_at TIMESTAMP NOT NULL DEFAULT now(),
     gm_id UUID NOT NULL REFERENCES gm(id) ON DELETE CASCADE
@@ -17,14 +17,14 @@ CREATE TABLE setting (
 
 CREATE TABLE genre (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    name VARCHAR(255) NOT NULL,
+    title VARCHAR(255) NOT NULL,
     code VARCHAR(255) NOT NULL UNIQUE,
     setting_id UUID NOT NULL REFERENCES setting(id) ON DELETE CASCADE
 );
 
 CREATE TABLE template (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    name VARCHAR(255) NOT NULL,
+    title VARCHAR(255) NOT NULL,
     description TEXT,
     created_at TIMESTAMP NOT NULL DEFAULT now(),
     type VARCHAR(255) NOT NULL,
@@ -37,7 +37,7 @@ CREATE INDEX template_json_schema_gin_idx ON template USING GIN (json_schema);
 CREATE TABLE setting_object (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     slug VARCHAR(255) NOT NULL,
-    name VARCHAR(255) NOT NULL,
+    title VARCHAR(255) NOT NULL,
     description TEXT,
     created_at TIMESTAMP NOT NULL DEFAULT now(),
     payload JSONB,
@@ -54,7 +54,7 @@ CREATE TABLE setting_object_tags (
 
 CREATE TABLE campaign (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    name VARCHAR(255) NOT NULL,
+    title VARCHAR(255) NOT NULL,
     started_on TIMESTAMP NOT NULL DEFAULT now(),
     gm_id UUID NOT NULL REFERENCES gm(id) ON DELETE CASCADE,
     setting_id UUID NOT NULL REFERENCES setting(id) ON DELETE CASCADE
@@ -62,7 +62,7 @@ CREATE TABLE campaign (
 
 CREATE TABLE campaign_object (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    name VARCHAR(255) NOT NULL,
+    title VARCHAR(255) NOT NULL,
     description TEXT,
     created_at TIMESTAMP NOT NULL DEFAULT now(),
     campaign_id UUID NOT NULL REFERENCES campaign(id) ON DELETE CASCADE,

--- a/src/test/kotlin/org/fg/ttrpg/relationship/RelationshipRepositoriesIT.kt
+++ b/src/test/kotlin/org/fg/ttrpg/relationship/RelationshipRepositoriesIT.kt
@@ -55,8 +55,8 @@ class RelationshipRepositoriesIT {
 
         jdbi.useHandle<Exception> { h ->
             h.execute("INSERT INTO gm (id, username) VALUES (?, ?)", gmId, "gm")
-            h.execute("INSERT INTO setting (id, name, gm_id, created_at) VALUES (?, ?, ?, now())", settingId, "world", gmId)
-            h.execute("INSERT INTO campaign (id, name, gm_id, setting_id, started_on) VALUES (?, ?, ?, ?, now())", campaignId, "camp", gmId, settingId)
+            h.execute("INSERT INTO setting (id, title, gm_id, created_at) VALUES (?, ?, ?, now())", settingId, "world", gmId)
+            h.execute("INSERT INTO campaign (id, title, gm_id, setting_id, started_on) VALUES (?, ?, ?, ?, now())", campaignId, "camp", gmId, settingId)
             h.createUpdate("INSERT INTO relationship_override (id, campaign_id, override_mode, properties, created_at) VALUES (:id, :campaignId, :mode, '{}'::jsonb, now())")
                 .bind("id", overrideId)
                 .bind("campaignId", campaignId)
@@ -87,9 +87,9 @@ class RelationshipRepositoriesIT {
 
         jdbi.useHandle<Exception> { h ->
             h.execute("INSERT INTO gm (id, username) VALUES (?, ?)", gmId, "gm")
-            h.execute("INSERT INTO setting (id, name, gm_id, created_at) VALUES (?, ?, ?, now())", settingId, "world", gmId)
-            h.execute("INSERT INTO setting_object (id, slug, name, setting_id, gm_id, created_at) VALUES (?, 'src', 'src', ?, ?, now())", srcObj, settingId, gmId)
-            h.execute("INSERT INTO setting_object (id, slug, name, setting_id, gm_id, created_at) VALUES (?, 'tgt', 'tgt', ?, ?, now())", tgtObj, settingId, gmId)
+            h.execute("INSERT INTO setting (id, title, gm_id, created_at) VALUES (?, ?, ?, now())", settingId, "world", gmId)
+            h.execute("INSERT INTO setting_object (id, slug, title, setting_id, gm_id, created_at) VALUES (?, 'src', 'src', ?, ?, now())", srcObj, settingId, gmId)
+            h.execute("INSERT INTO setting_object (id, slug, title, setting_id, gm_id, created_at) VALUES (?, 'tgt', 'tgt', ?, ?, now())", tgtObj, settingId, gmId)
             h.execute("INSERT INTO relationship_type (id, setting_id, code, display_name, directional, created_at) VALUES (?, ?, 'friend', 'Friend', false, now())", typeId, settingId)
             h.execute("INSERT INTO relationship (id, setting_id, type_id, source_object, target_object, is_bidirectional, created_at) VALUES (?, ?, ?, ?, ?, false, now())", relId, settingId, typeId, srcObj, tgtObj)
         }


### PR DESCRIPTION
## Summary
- rename `name` columns to `title` in Liquibase migrations
- update repositories to use the `title` column
- fix relationship repository test SQL

## Testing
- `./gradlew test --no-daemon` *(fails: Could not find a valid Docker environment)*

------
https://chatgpt.com/codex/tasks/task_e_685aa8dc671883259dda9cf5e95f81f1