### PR TITLE
Add calendar and timeline repositories

### DIFF
--- a/src/main/kotlin/org/fg/ttrpg/calendar/CalendarSystem.kt
+++ b/src/main/kotlin/org/fg/ttrpg/calendar/CalendarSystem.kt
@@ -1,0 +1,16 @@
+package org.fg.ttrpg.calendar
+
+import java.time.Instant
+import java.util.UUID
+
+class CalendarSystem {
+    var id: UUID? = null
+    var name: String? = null
+    var epochLabel: String? = null
+    /** JSON description of months and their day counts */
+    var months: String? = null
+    /** JSON description of leap year rules */
+    var leapRule: String? = null
+    var createdAt: Instant? = null
+    var setting: org.fg.ttrpg.setting.Setting? = null
+}

--- a/src/main/kotlin/org/fg/ttrpg/calendar/CalendarSystemRepository.kt
+++ b/src/main/kotlin/org/fg/ttrpg/calendar/CalendarSystemRepository.kt
@@ -1,0 +1,94 @@
+package org.fg.ttrpg.calendar
+
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import org.fg.ttrpg.setting.Setting
+import org.jdbi.v3.core.Jdbi
+import org.jdbi.v3.core.mapper.RowMapper
+import org.jdbi.v3.core.statement.StatementContext
+import java.sql.ResultSet
+import java.util.UUID
+
+@ApplicationScoped
+class CalendarSystemRepository @Inject constructor(private val jdbi: Jdbi) {
+
+    fun listBySetting(settingId: UUID): List<CalendarSystem> =
+        jdbi.withHandle<List<CalendarSystem>, Exception> { handle ->
+            handle.createQuery(
+                "SELECT id, setting_id, name, epoch_label, months, leap_rule, created_at FROM calendar_system WHERE setting_id = :settingId"
+            )
+                .bind("settingId", settingId)
+                .map(CalendarSystemMapper())
+                .list()
+        }
+
+    fun findById(id: UUID): CalendarSystem? =
+        jdbi.withHandle<CalendarSystem?, Exception> { handle ->
+            handle.createQuery(
+                "SELECT id, setting_id, name, epoch_label, months, leap_rule, created_at FROM calendar_system WHERE id = :id"
+            )
+                .bind("id", id)
+                .map(CalendarSystemMapper())
+                .findOne()
+                .orElse(null)
+        }
+
+    fun findByIdForSetting(id: UUID, settingId: UUID): CalendarSystem? =
+        jdbi.withHandle<CalendarSystem?, Exception> { handle ->
+            handle.createQuery(
+                "SELECT id, setting_id, name, epoch_label, months, leap_rule, created_at FROM calendar_system WHERE id = :id AND setting_id = :settingId"
+            )
+                .bind("id", id)
+                .bind("settingId", settingId)
+                .map(CalendarSystemMapper())
+                .findOne()
+                .orElse(null)
+        }
+
+    fun persist(system: CalendarSystem) {
+        if (system.id == null) {
+            system.id = UUID.randomUUID()
+        }
+        jdbi.useHandle<Exception> { handle ->
+            if (system.createdAt != null) {
+                handle.createUpdate(
+                    "INSERT INTO calendar_system (id, setting_id, name, epoch_label, months, leap_rule, created_at) VALUES (:id, :settingId, :name, :epochLabel, :months::jsonb, :leapRule::jsonb, :createdAt)"
+                )
+                    .bind("id", system.id)
+                    .bind("settingId", system.setting?.id)
+                    .bind("name", system.name)
+                    .bind("epochLabel", system.epochLabel)
+                    .bind("months", system.months)
+                    .bind("leapRule", system.leapRule)
+                    .bind("createdAt", system.createdAt)
+                    .execute()
+            } else {
+                handle.createUpdate(
+                    "INSERT INTO calendar_system (id, setting_id, name, epoch_label, months, leap_rule) VALUES (:id, :settingId, :name, :epochLabel, :months::jsonb, :leapRule::jsonb)"
+                )
+                    .bind("id", system.id)
+                    .bind("settingId", system.setting?.id)
+                    .bind("name", system.name)
+                    .bind("epochLabel", system.epochLabel)
+                    .bind("months", system.months)
+                    .bind("leapRule", system.leapRule)
+                    .execute()
+            }
+        }
+    }
+
+    private class CalendarSystemMapper : RowMapper<CalendarSystem> {
+        override fun map(rs: ResultSet, ctx: StatementContext): CalendarSystem = CalendarSystem().apply {
+            id = rs.getObject("id", UUID::class.java)
+            setting = Setting().apply { id = rs.getObject("setting_id", UUID::class.java) }
+            name = rs.getString("name")
+            epochLabel = rs.getString("epoch_label")
+            months = rs.getString("months")
+            leapRule = rs.getString("leap_rule")
+            val ts = rs.getTimestamp("created_at")
+            if (ts != null) {
+                createdAt = ts.toInstant()
+            }
+        }
+    }
+}

--- a/src/main/kotlin/org/fg/ttrpg/campaign/CampaignEventOverride.kt
+++ b/src/main/kotlin/org/fg/ttrpg/campaign/CampaignEventOverride.kt
@@ -1,0 +1,16 @@
+package org.fg.ttrpg.campaign
+
+import org.fg.ttrpg.timeline.TimelineEvent
+import java.time.Instant
+import java.util.UUID
+
+class CampaignEventOverride {
+    var id: UUID? = null
+    var campaign: Campaign? = null
+    var baseEvent: TimelineEvent? = null
+    var overrideMode: OverrideMode? = null
+    var payload: String? = null
+    var createdAt: Instant? = null
+}
+
+enum class OverrideMode { PATCH, REPLACE, DELETE }

--- a/src/main/kotlin/org/fg/ttrpg/campaign/CampaignEventOverrideRepository.kt
+++ b/src/main/kotlin/org/fg/ttrpg/campaign/CampaignEventOverrideRepository.kt
@@ -1,0 +1,92 @@
+package org.fg.ttrpg.campaign
+
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import org.fg.ttrpg.timeline.TimelineEvent
+import org.jdbi.v3.core.Jdbi
+import org.jdbi.v3.core.mapper.RowMapper
+import org.jdbi.v3.core.statement.StatementContext
+import java.sql.ResultSet
+import java.util.UUID
+
+@ApplicationScoped
+class CampaignEventOverrideRepository @Inject constructor(private val jdbi: Jdbi) {
+
+    fun list(): List<CampaignEventOverride> =
+        jdbi.withHandle<List<CampaignEventOverride>, Exception> { handle ->
+            handle.createQuery(
+                "SELECT id, campaign_id, base_event_id, override_mode, payload, created_at FROM campaign_event_override"
+            )
+                .map(CampaignEventOverrideMapper())
+                .list()
+        }
+
+    fun findById(id: UUID): CampaignEventOverride? =
+        jdbi.withHandle<CampaignEventOverride?, Exception> { handle ->
+            handle.createQuery(
+                "SELECT id, campaign_id, base_event_id, override_mode, payload, created_at FROM campaign_event_override WHERE id = :id"
+            )
+                .bind("id", id)
+                .map(CampaignEventOverrideMapper())
+                .findOne()
+                .orElse(null)
+        }
+
+    fun persist(override: CampaignEventOverride) {
+        jdbi.useHandle<Exception> { handle ->
+            handle.createUpdate(
+                "INSERT INTO campaign_event_override (id, campaign_id, base_event_id, override_mode, payload, created_at) VALUES (:id, :campaignId, :baseEventId, :overrideMode, :payload::jsonb, :createdAt)"
+            )
+                .bind("id", override.id)
+                .bind("campaignId", override.campaign?.id)
+                .bind("baseEventId", override.baseEvent?.id)
+                .bind("overrideMode", override.overrideMode?.name)
+                .bind("payload", override.payload)
+                .bind("createdAt", override.createdAt)
+                .execute()
+        }
+    }
+
+    fun update(override: CampaignEventOverride) {
+        jdbi.useHandle<Exception> { handle ->
+            handle.createUpdate(
+                """
+                UPDATE campaign_event_override SET
+                    campaign_id = :campaignId,
+                    base_event_id = :baseEventId,
+                    override_mode = :overrideMode,
+                    payload = :payload::jsonb
+                WHERE id = :id
+                """
+            )
+                .bind("id", override.id)
+                .bind("campaignId", override.campaign?.id)
+                .bind("baseEventId", override.baseEvent?.id)
+                .bind("overrideMode", override.overrideMode?.name)
+                .bind("payload", override.payload)
+                .execute()
+        }
+    }
+
+    fun deleteById(id: UUID) {
+        jdbi.useHandle<Exception> { handle ->
+            handle.createUpdate("DELETE FROM campaign_event_override WHERE id = :id")
+                .bind("id", id)
+                .execute()
+        }
+    }
+
+    private class CampaignEventOverrideMapper : RowMapper<CampaignEventOverride> {
+        override fun map(rs: ResultSet, ctx: StatementContext): CampaignEventOverride = CampaignEventOverride().apply {
+            id = rs.getObject("id", UUID::class.java)
+            campaign = Campaign().apply { id = rs.getObject("campaign_id", UUID::class.java) }
+            val baseId = rs.getObject("base_event_id", UUID::class.java)
+            if (baseId != null) {
+                baseEvent = TimelineEvent().apply { id = baseId }
+            }
+            overrideMode = OverrideMode.valueOf(rs.getString("override_mode"))
+            payload = rs.getString("payload")
+            createdAt = rs.getTimestamp("created_at").toInstant()
+        }
+    }
+}

--- a/src/main/kotlin/org/fg/ttrpg/timeline/TimelineEvent.kt
+++ b/src/main/kotlin/org/fg/ttrpg/timeline/TimelineEvent.kt
@@ -1,0 +1,14 @@
+package org.fg.ttrpg.timeline
+
+import java.util.UUID
+
+class TimelineEvent {
+    var id: UUID? = null
+    var calendar: org.fg.ttrpg.calendar.CalendarSystem? = null
+    var title: String? = null
+    var description: String? = null
+    var startDay: Int? = null
+    var endDay: Int? = null
+    var objectRefs: MutableList<org.fg.ttrpg.setting.SettingObject> = mutableListOf()
+    var tags: MutableList<String> = mutableListOf()
+}

--- a/src/main/kotlin/org/fg/ttrpg/timeline/TimelineEventRepository.kt
+++ b/src/main/kotlin/org/fg/ttrpg/timeline/TimelineEventRepository.kt
@@ -1,0 +1,94 @@
+package org.fg.ttrpg.timeline
+
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import org.fg.ttrpg.calendar.CalendarSystem
+import org.fg.ttrpg.setting.SettingObject
+import org.jdbi.v3.core.Jdbi
+import org.jdbi.v3.core.mapper.RowMapper
+import org.jdbi.v3.core.statement.StatementContext
+import java.sql.ResultSet
+import java.util.UUID
+
+@ApplicationScoped
+class TimelineEventRepository @Inject constructor(private val jdbi: Jdbi) {
+
+    fun listByCalendar(calendarId: UUID): List<TimelineEvent> =
+        jdbi.withHandle<List<TimelineEvent>, Exception> { handle ->
+            handle.createQuery(
+                "SELECT id, calendar_id, title, description, start_day, end_day, object_refs, tags FROM timeline_event WHERE calendar_id = :calendarId"
+            )
+                .bind("calendarId", calendarId)
+                .map(TimelineEventMapper())
+                .list()
+        }
+
+    fun findById(id: UUID): TimelineEvent? =
+        jdbi.withHandle<TimelineEvent?, Exception> { handle ->
+            handle.createQuery(
+                "SELECT id, calendar_id, title, description, start_day, end_day, object_refs, tags FROM timeline_event WHERE id = :id"
+            )
+                .bind("id", id)
+                .map(TimelineEventMapper())
+                .findOne()
+                .orElse(null)
+        }
+
+    fun findByIdForCalendar(id: UUID, calendarId: UUID): TimelineEvent? =
+        jdbi.withHandle<TimelineEvent?, Exception> { handle ->
+            handle.createQuery(
+                "SELECT id, calendar_id, title, description, start_day, end_day, object_refs, tags FROM timeline_event WHERE id = :id AND calendar_id = :calendarId"
+            )
+                .bind("id", id)
+                .bind("calendarId", calendarId)
+                .map(TimelineEventMapper())
+                .findOne()
+                .orElse(null)
+        }
+
+    fun persist(event: TimelineEvent) {
+        if (event.id == null) {
+            event.id = UUID.randomUUID()
+        }
+        jdbi.useHandle<Exception> { handle ->
+            handle.createUpdate(
+                "INSERT INTO timeline_event (id, calendar_id, title, description, start_day, end_day, object_refs, tags) VALUES (:id, :calendarId, :title, :description, :startDay, :endDay, :objectRefs, :tags)"
+            )
+                .bind("id", event.id)
+                .bind("calendarId", event.calendar?.id)
+                .bind("title", event.title)
+                .bind("description", event.description)
+                .bind("startDay", event.startDay)
+                .bind("endDay", event.endDay)
+                .bind("objectRefs", event.objectRefs.takeIf { it.isNotEmpty() }?.toTypedArray())
+                .bind("tags", event.tags.takeIf { it.isNotEmpty() }?.toTypedArray())
+                .execute()
+        }
+    }
+
+    private class TimelineEventMapper : RowMapper<TimelineEvent> {
+        override fun map(rs: ResultSet, ctx: StatementContext): TimelineEvent = TimelineEvent().apply {
+            id = rs.getObject("id", UUID::class.java)
+            calendar = CalendarSystem().apply { id = rs.getObject("calendar_id", UUID::class.java) }
+            title = rs.getString("title")
+            description = rs.getString("description")
+            startDay = rs.getInt("start_day")
+            val end = rs.getInt("end_day")
+            if (!rs.wasNull()) {
+                endDay = end
+            }
+            val objArray = rs.getArray("object_refs")
+            if (objArray != null) {
+                @Suppress("UNCHECKED_CAST")
+                val arr = objArray.array as Array<Any>
+                objectRefs = arr.map { SettingObject().apply { id = UUID.fromString(it.toString()) } }.toMutableList()
+            }
+            val tagArray = rs.getArray("tags")
+            if (tagArray != null) {
+                @Suppress("UNCHECKED_CAST")
+                val arr = tagArray.array as Array<Any>
+                tags = arr.map { it.toString() }.toMutableList()
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add CalendarSystem model and repository for setting calendars
- add TimelineEvent model and repository
- support campaign-level overrides of timeline events

## Testing
- `./gradlew test` *(fails: Could not find a valid Docker environment)*

------
https://chatgpt.com/codex/tasks/task_e_685ab8780f94832581d0ad923d1680a3