### PR TITLE
Add services for calendar and timeline

### DIFF
--- a/src/main/kotlin/org/fg/ttrpg/calendar/CalendarService.kt
+++ b/src/main/kotlin/org/fg/ttrpg/calendar/CalendarService.kt
@@ -1,0 +1,41 @@
+package org.fg.ttrpg.calendar
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import java.util.UUID
+
+@ApplicationScoped
+class CalendarService @Inject constructor(private val repository: CalendarSystemRepository) {
+    private val mapper = ObjectMapper()
+
+    fun listBySetting(settingId: UUID): List<CalendarSystem> =
+        repository.listBySetting(settingId)
+
+    fun findById(id: UUID): CalendarSystem? = repository.findById(id)
+
+    fun findByIdForSetting(id: UUID, settingId: UUID): CalendarSystem? =
+        repository.findByIdForSetting(id, settingId)
+
+    fun persist(system: CalendarSystem) {
+        repository.persist(system)
+    }
+
+    /** Calculate the total number of days in one year. */
+    fun totalDays(system: CalendarSystem): Int =
+        parseMonths(system).sumOf { it.days }
+
+    /** Validate that a day-of-year exists in the calendar. */
+    fun isValidDay(system: CalendarSystem, day: Int): Boolean {
+        val total = totalDays(system)
+        return day in 1..total
+    }
+
+    private data class Month(val name: String, val days: Int)
+
+    private fun parseMonths(system: CalendarSystem): List<Month> =
+        runCatching {
+            val node = mapper.readTree(system.months ?: "[]")
+            node.map { Month(it.get("name").asText(), it.get("days").asInt()) }
+        }.getOrDefault(emptyList())
+}

--- a/src/main/kotlin/org/fg/ttrpg/campaign/CampaignEventService.kt
+++ b/src/main/kotlin/org/fg/ttrpg/campaign/CampaignEventService.kt
@@ -1,0 +1,56 @@
+package org.fg.ttrpg.campaign
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import org.fg.ttrpg.infra.merge.MergeService
+import org.fg.ttrpg.timeline.TimelineEvent
+import java.util.UUID
+
+@ApplicationScoped
+class CampaignEventService @Inject constructor(
+    private val repository: CampaignEventOverrideRepository,
+    private val merge: MergeService
+) {
+    private val mapper = ObjectMapper()
+
+    fun list(): List<CampaignEventOverride> = repository.list()
+
+    fun findById(id: UUID): CampaignEventOverride? = repository.findById(id)
+
+    fun persist(override: CampaignEventOverride) {
+        repository.persist(override)
+    }
+
+    fun update(override: CampaignEventOverride) {
+        repository.update(override)
+    }
+
+    fun deleteById(id: UUID) {
+        repository.deleteById(id)
+    }
+
+    /**
+     * Apply an override to a base timeline event and return the result.
+     * DELETE overrides return null.
+     */
+    fun applyOverride(base: TimelineEvent, override: CampaignEventOverride): TimelineEvent? {
+        return when (override.overrideMode) {
+            OverrideMode.DELETE -> null
+            OverrideMode.REPLACE -> mapper.readValue(override.payload ?: "{}", TimelineEvent::class.java)
+                .apply {
+                    id = base.id
+                    calendar = base.calendar
+                }
+            OverrideMode.PATCH -> {
+                val baseJson = mapper.writeValueAsString(base)
+                val merged = merge.merge(baseJson, override.payload ?: "{}")
+                mapper.readValue(merged, TimelineEvent::class.java).apply {
+                    id = base.id
+                    calendar = base.calendar
+                }
+            }
+            null -> base
+        }
+    }
+}

--- a/src/main/kotlin/org/fg/ttrpg/timeline/TimelineService.kt
+++ b/src/main/kotlin/org/fg/ttrpg/timeline/TimelineService.kt
@@ -1,0 +1,20 @@
+package org.fg.ttrpg.timeline
+
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import java.util.UUID
+
+@ApplicationScoped
+class TimelineService @Inject constructor(private val repository: TimelineEventRepository) {
+    fun listByCalendar(calendarId: UUID): List<TimelineEvent> =
+        repository.listByCalendar(calendarId)
+
+    fun findById(id: UUID): TimelineEvent? = repository.findById(id)
+
+    fun findByIdForCalendar(id: UUID, calendarId: UUID): TimelineEvent? =
+        repository.findByIdForCalendar(id, calendarId)
+
+    fun persist(event: TimelineEvent) {
+        repository.persist(event)
+    }
+}


### PR DESCRIPTION
## Summary
- add `CalendarService` for calendar CRUD operations
- add `TimelineService` for handling timeline events
- add `CampaignEventService` to apply event overrides

## Testing
- `./gradlew test --no-daemon` *(fails: Could not find a valid Docker environment)*

------
https://chatgpt.com/codex/tasks/task_e_685abc12c84c832589779a19b98c8aee