### PR TITLE
Implement Calendar and Campaign event endpoints

### DIFF
--- a/src/main/kotlin/org/fg/ttrpg/campaign/CampaignEventOverrideRepository.kt
+++ b/src/main/kotlin/org/fg/ttrpg/campaign/CampaignEventOverrideRepository.kt
@@ -76,6 +76,28 @@ class CampaignEventOverrideRepository @Inject constructor(private val jdbi: Jdbi
         }
     }
 
+    fun listByCampaign(campaignId: UUID): List<CampaignEventOverride> =
+        jdbi.withHandle<List<CampaignEventOverride>, Exception> { handle ->
+            handle.createQuery(
+                "SELECT id, campaign_id, base_event_id, override_mode, payload, created_at FROM campaign_event_override WHERE campaign_id = :cid"
+            )
+                .bind("cid", campaignId)
+                .map(CampaignEventOverrideMapper())
+                .list()
+        }
+
+    fun findByCampaignAndEvent(campaignId: UUID, eventId: UUID): CampaignEventOverride? =
+        jdbi.withHandle<CampaignEventOverride?, Exception> { handle ->
+            handle.createQuery(
+                "SELECT id, campaign_id, base_event_id, override_mode, payload, created_at FROM campaign_event_override WHERE campaign_id = :cid AND base_event_id = :eid"
+            )
+                .bind("cid", campaignId)
+                .bind("eid", eventId)
+                .map(CampaignEventOverrideMapper())
+                .findOne()
+                .orElse(null)
+        }
+
     private class CampaignEventOverrideMapper : RowMapper<CampaignEventOverride> {
         override fun map(rs: ResultSet, ctx: StatementContext): CampaignEventOverride = CampaignEventOverride().apply {
             id = rs.getObject("id", UUID::class.java)

--- a/src/main/kotlin/org/fg/ttrpg/campaign/CampaignEventService.kt
+++ b/src/main/kotlin/org/fg/ttrpg/campaign/CampaignEventService.kt
@@ -18,6 +18,12 @@ class CampaignEventService @Inject constructor(
 
     fun findById(id: UUID): CampaignEventOverride? = repository.findById(id)
 
+    fun listByCampaign(campaignId: UUID): List<CampaignEventOverride> =
+        repository.listByCampaign(campaignId)
+
+    fun findByCampaignAndEvent(campaignId: UUID, eventId: UUID): CampaignEventOverride? =
+        repository.findByCampaignAndEvent(campaignId, eventId)
+
     fun persist(override: CampaignEventOverride) {
         repository.persist(override)
     }

--- a/src/main/kotlin/org/fg/ttrpg/campaign/resource/CampaignEventResource.kt
+++ b/src/main/kotlin/org/fg/ttrpg/campaign/resource/CampaignEventResource.kt
@@ -1,0 +1,100 @@
+package org.fg.ttrpg.campaign.resource
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import jakarta.inject.Inject
+import jakarta.transaction.Transactional
+import jakarta.ws.rs.*
+import jakarta.ws.rs.core.MediaType
+import org.eclipse.microprofile.jwt.JsonWebToken
+import org.fg.ttrpg.calendar.CalendarService
+import org.fg.ttrpg.campaign.*
+import org.fg.ttrpg.common.dto.CampaignEventOverrideDTO
+import org.fg.ttrpg.common.dto.TimelineEventDTO
+import org.fg.ttrpg.setting.SettingService
+import org.fg.ttrpg.timeline.TimelineEvent
+import org.fg.ttrpg.timeline.TimelineService
+import java.time.Instant
+import java.util.UUID
+
+@Path("/api/campaigns")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+class CampaignEventResource @Inject constructor(
+    private val campaignService: CampaignService,
+    private val eventService: CampaignEventService,
+    private val calendarService: CalendarService,
+    private val timelineService: TimelineService,
+    private val settingService: SettingService,
+    private val jwt: JsonWebToken,
+) {
+    private val mapper = ObjectMapper()
+    private fun gmId() = UUID.fromString(jwt.getClaim("gmId"))
+
+    @PATCH
+    @Path("{cid}/events/{eid}")
+    @Transactional
+    fun patchEvent(
+        @PathParam("cid") cid: UUID,
+        @PathParam("eid") eid: UUID,
+        dto: CampaignEventOverrideDTO,
+    ): TimelineEventDTO {
+        val campaign = campaignService.findByIdForGm(cid, gmId()) ?: throw NotFoundException()
+        val base = timelineService.findById(eid) ?: throw NotFoundException()
+        var override = eventService.findByCampaignAndEvent(cid, eid)
+        if (override == null) {
+            override = CampaignEventOverride().apply {
+                id = UUID.randomUUID()
+                this.campaign = campaign
+                this.baseEvent = base
+                createdAt = Instant.now()
+            }
+            eventService.persist(override)
+        }
+        override.overrideMode = OverrideMode.valueOf(dto.overrideMode)
+        override.payload = dto.payload
+        eventService.update(override)
+        val result = eventService.applyOverride(base, override) ?: throw NotFoundException()
+        return result.toDto()
+    }
+
+    @GET
+    @Path("{cid}/timeline")
+    fun timeline(
+        @PathParam("cid") cid: UUID,
+        @QueryParam("from") from: Int?,
+        @QueryParam("to") to: Int?,
+    ): List<TimelineEventDTO> {
+        val campaign = campaignService.findByIdForGm(cid, gmId()) ?: throw NotFoundException()
+        val settingId = campaign.setting?.id ?: throw NotFoundException()
+        val calendars = calendarService.listBySetting(settingId)
+        val baseEvents = calendars.flatMap { timelineService.listByCalendar(it.id!!) }.toMutableList()
+        val overrides = eventService.listByCampaign(cid)
+        overrides.forEach { ov ->
+            val baseId = ov.baseEvent?.id
+            if (baseId != null) {
+                val base = baseEvents.find { it.id == baseId }
+                if (base != null) {
+                    baseEvents.remove(base)
+                    eventService.applyOverride(base, ov)?.let { baseEvents.add(it) }
+                }
+            } else {
+                val newEvent = mapper.readValue(ov.payload ?: "{}", TimelineEvent::class.java)
+                baseEvents.add(newEvent)
+            }
+        }
+        val start = from ?: Int.MIN_VALUE
+        val end = to ?: Int.MAX_VALUE
+        return baseEvents.filter { (it.startDay ?: 0) in start..end }.map { it.toDto() }
+    }
+}
+
+private fun TimelineEvent.toDto() = TimelineEventDTO(
+    id,
+    calendar?.id ?: error("Calendar is null"),
+    title ?: "",
+    description,
+    startDay ?: 0,
+    endDay,
+    objectRefs.map { it.id ?: error("id") },
+    tags.toList(),
+)

--- a/src/main/kotlin/org/fg/ttrpg/common/dto/CalendarDTO.kt
+++ b/src/main/kotlin/org/fg/ttrpg/common/dto/CalendarDTO.kt
@@ -1,0 +1,13 @@
+package org.fg.ttrpg.common.dto
+
+import java.util.UUID
+
+/** DTO for calendar systems. */
+data class CalendarDTO(
+    val id: UUID?,
+    val name: String,
+    val epochLabel: String? = null,
+    val months: String? = null,
+    val leapRule: String? = null,
+    val settingId: UUID,
+)

--- a/src/main/kotlin/org/fg/ttrpg/common/dto/CampaignEventOverrideDTO.kt
+++ b/src/main/kotlin/org/fg/ttrpg/common/dto/CampaignEventOverrideDTO.kt
@@ -1,0 +1,12 @@
+package org.fg.ttrpg.common.dto
+
+import java.util.UUID
+
+/** DTO for campaign-specific timeline event overrides. */
+data class CampaignEventOverrideDTO(
+    val id: UUID?,
+    val campaignId: UUID,
+    val baseEventId: UUID?,
+    val overrideMode: String,
+    val payload: String? = null,
+)

--- a/src/main/kotlin/org/fg/ttrpg/common/dto/TimelineEventDTO.kt
+++ b/src/main/kotlin/org/fg/ttrpg/common/dto/TimelineEventDTO.kt
@@ -1,0 +1,15 @@
+package org.fg.ttrpg.common.dto
+
+import java.util.UUID
+
+/** DTO for timeline events. */
+data class TimelineEventDTO(
+    val id: UUID?,
+    val calendarId: UUID,
+    val title: String,
+    val description: String? = null,
+    val startDay: Int,
+    val endDay: Int? = null,
+    val objectRefs: List<UUID> = emptyList(),
+    val tags: List<String> = emptyList(),
+)

--- a/src/test/kotlin/org/fg/ttrpg/CalendarResourceIT.kt
+++ b/src/test/kotlin/org/fg/ttrpg/CalendarResourceIT.kt
@@ -1,0 +1,99 @@
+package org.fg.ttrpg
+
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.quarkus.test.security.jwt.Claim
+import io.quarkus.test.security.jwt.JwtSecurity
+import io.restassured.RestAssured.given
+import io.restassured.http.ContentType
+import jakarta.inject.Inject
+import jakarta.transaction.Transactional
+import org.fg.ttrpg.account.GM
+import org.fg.ttrpg.account.GMRepository
+import org.fg.ttrpg.common.dto.CalendarDTO
+import org.fg.ttrpg.common.dto.TimelineEventDTO
+import org.fg.ttrpg.setting.Setting
+import org.fg.ttrpg.setting.SettingRepository
+import org.hamcrest.CoreMatchers.equalTo
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.*
+
+@QuarkusTest
+class CalendarResourceIT {
+    @Inject
+    lateinit var gmRepo: GMRepository
+
+    @Inject
+    lateinit var settingRepo: SettingRepository
+
+    val gmId = UUID.fromString("00000000-0000-0000-0000-000000000010")
+
+    lateinit var setting: Setting
+
+    @BeforeEach
+    fun setup() {
+        createGm(gmId)
+        setting = createSetting(UUID.randomUUID(), gmId)
+    }
+
+    @AfterEach
+    fun cleanup() {
+        gmRepo.deleteById(gmId)
+    }
+
+    @Transactional
+    fun createGm(id: UUID) {
+        val gm = GM().apply {
+            this.id = id
+            username = "gm-$id"
+        }
+        gmRepo.persist(gm)
+    }
+
+    @Transactional
+    fun createSetting(id: UUID, gmId: UUID): Setting {
+        val gm = gmRepo.findById(gmId)
+        val setting = Setting().apply {
+            this.id = id
+            title = "world"
+            this.gm = gm
+        }
+        settingRepo.persist(setting)
+        return setting
+    }
+
+    @Test
+    @TestSecurity(user = "userJwt", roles = ["viewer"])
+    @JwtSecurity(
+        claims = [
+            Claim(key = "email", value = "user@gmail.com"),
+            Claim(key = "sub", value = "userJwt"),
+            Claim(key = "gmId", value = "00000000-0000-0000-0000-000000000010")
+        ]
+    )
+    fun createCalendar_and_event() {
+        val calendarDto = CalendarDTO(null, "Cal", "CE", "[]", null, setting.id!!)
+        val calendarId =
+            given()
+                .contentType(ContentType.JSON)
+                .body(calendarDto)
+                .`when`().post("/api/settings/${setting.id}/calendars")
+                .then().statusCode(200)
+                .extract().path<String>("id")
+
+        given()
+            .`when`().get("/api/calendars/$calendarId")
+            .then().statusCode(200)
+            .body("name", equalTo("Cal"))
+
+        val eventDto = TimelineEventDTO(null, UUID.fromString(calendarId), "Start", null, 1, null)
+        given()
+            .contentType(ContentType.JSON)
+            .body(eventDto)
+            .`when`().post("/api/calendars/$calendarId/events")
+            .then().statusCode(200)
+            .body("title", equalTo("Start"))
+    }
+}


### PR DESCRIPTION
## Summary
- add DTOs for calendars and timeline events
- support calendar CRUD and event creation
- allow campaign timeline overrides and timeline retrieval
- include minimal integration test for calendar resource

## Testing
- `./gradlew classes --no-daemon`
- `./gradlew test --no-daemon` *(fails: Could not find a valid Docker environment)*

------
https://chatgpt.com/codex/tasks/task_e_685abe83abe0832588dafebd3169a51b