### PR TITLE
Add OpenAPI endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,7 @@ GET  /api/campaigns/{cid}/timeline      - list events for a campaign
 ## Conventions
 
 When referring to entity attributes that represent a human readable label use the column name `title` instead of `name`. This keeps database names consistent with the Kotlin domain model.
+
+## API Documentation
+
+Swagger UI is available when the application runs, providing interactive API docs at `http://localhost:8080/swagger-ui`. The raw OpenAPI specification can be retrieved from `http://localhost:8080/openapi`.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     implementation("io.quarkus:quarkus-liquibase")
     implementation("io.quarkus:quarkus-jdbc-postgresql")
     implementation("io.quarkus:quarkus-smallrye-jwt")
+    implementation("io.quarkus:quarkus-smallrye-openapi")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("io.quarkus:quarkus-arc")
     implementation("com.networknt:json-schema-validator:1.5.6")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,11 @@ quarkus:
   liquibase:
     change-log: db/changelog/db.changelog-master.yaml
     migrate-at-start: true
+  smallrye-openapi:
+    path: /openapi
+  swagger-ui:
+    path: /swagger-ui
+    always-include: true
 
 # JWT Configuration - applies to all profiles
 mp:

--- a/src/test/kotlin/org/fg/ttrpg/OpenApiResourceIT.kt
+++ b/src/test/kotlin/org/fg/ttrpg/OpenApiResourceIT.kt
@@ -1,0 +1,17 @@
+package org.fg.ttrpg
+
+import io.quarkus.test.junit.QuarkusTest
+import io.restassured.RestAssured.given
+import org.junit.jupiter.api.Test
+
+@QuarkusTest
+class OpenApiResourceIT {
+
+    @Test
+    fun openapiEndpointAccessible() {
+        given()
+            .`when`().get("/openapi")
+            .then()
+            .statusCode(200)
+    }
+}


### PR DESCRIPTION
## Summary
- add quarkus-smallrye-openapi dependency
- configure OpenAPI and Swagger UI paths
- document API docs location in README
- add integration test for `/openapi`

## Testing
- `./gradlew test` *(fails: Could not find a valid Docker environment)*

------
https://chatgpt.com/codex/tasks/task_e_685af92ff6b483259ffec51deb755db6