### PR TITLE
Convert tests to Kotest matchers

### DIFF
--- a/src/test/kotlin/org/fg/ttrpg/CampaignResourceIT.kt
+++ b/src/test/kotlin/org/fg/ttrpg/CampaignResourceIT.kt
@@ -16,6 +16,7 @@ import jakarta.inject.Inject
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import jakarta.transaction.Transactional
+import io.kotest.matchers.shouldBe
 import java.util.*
 
 
@@ -273,6 +274,6 @@ class CampaignResourceIT : IntegrationTestHelper() {
     @Transactional
     fun verifyPayload(id: UUID, expected: String) {
         val obj = campaignObjectRepo.findById(id)
-        org.junit.jupiter.api.Assertions.assertEquals(expected, obj!!.payload)
+        obj!!.payload shouldBe expected
     }
 }

--- a/src/test/kotlin/org/fg/ttrpg/SettingResourceIT.kt
+++ b/src/test/kotlin/org/fg/ttrpg/SettingResourceIT.kt
@@ -15,6 +15,7 @@ import org.hamcrest.CoreMatchers.equalTo
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
+import io.kotest.matchers.shouldBe
 import org.fg.ttrpg.testutils.IntegrationTestHelper
 import java.util.*
 
@@ -180,17 +181,17 @@ class SettingResourceIT : IntegrationTestHelper() {
     @TestTransaction
     fun verifySettings(gmId: UUID, expected: Int) {
         val count = settingRepo.listByGm(gmId).size
-        org.junit.jupiter.api.Assertions.assertEquals(expected, count)
+        count shouldBe expected
     }
 
     @TestTransaction
     fun verifyObject(settingId: UUID, gmId: UUID, templateId: UUID) {
         val objs = objectRepo.listBySettingAndGm(settingId, gmId)
-        org.junit.jupiter.api.Assertions.assertEquals(1, objs.size)
+        objs.size shouldBe 1
         val obj = objs.first()
-        org.junit.jupiter.api.Assertions.assertEquals("slug", obj.slug)
-        org.junit.jupiter.api.Assertions.assertEquals("Title", obj.title)
-        org.junit.jupiter.api.Assertions.assertEquals("{\"name\": \"obj\"}", obj.payload)
-        org.junit.jupiter.api.Assertions.assertEquals(templateId, obj.template?.id)
+        obj.slug shouldBe "slug"
+        obj.title shouldBe "Title"
+        obj.payload shouldBe "{\"name\": \"obj\"}"
+        obj.template?.id shouldBe templateId
     }
 }

--- a/src/test/kotlin/org/fg/ttrpg/campaign/CampaignEventServiceTest.kt
+++ b/src/test/kotlin/org/fg/ttrpg/campaign/CampaignEventServiceTest.kt
@@ -5,7 +5,9 @@ import io.mockk.every
 import io.mockk.mockk
 import org.fg.ttrpg.infra.merge.MergeService
 import org.fg.ttrpg.timeline.TimelineEvent
-import org.junit.jupiter.api.Assertions.*
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.nulls.shouldBeNull
 import org.junit.jupiter.api.Test
 import java.util.*
 
@@ -19,7 +21,7 @@ class CampaignEventServiceTest {
     fun `list should return all overrides`() {
         val overrides = listOf(CampaignEventOverride())
         every { repository.list() } returns overrides
-        assertEquals(overrides, service.list())
+        service.list() shouldBe overrides
     }
 
     @Test
@@ -27,7 +29,7 @@ class CampaignEventServiceTest {
         val id = UUID.randomUUID()
         val override = CampaignEventOverride().apply { this.id = id }
         every { repository.findById(id) } returns override
-        assertEquals(override, service.findById(id))
+        service.findById(id) shouldBe override
     }
 
     @Test
@@ -35,7 +37,7 @@ class CampaignEventServiceTest {
         val campaignId = UUID.randomUUID()
         val overrides = listOf(CampaignEventOverride())
         every { repository.listByCampaign(campaignId) } returns overrides
-        assertEquals(overrides, service.listByCampaign(campaignId))
+        service.listByCampaign(campaignId) shouldBe overrides
     }
 
     @Test
@@ -44,14 +46,14 @@ class CampaignEventServiceTest {
         val eventId = UUID.randomUUID()
         val override = CampaignEventOverride()
         every { repository.findByCampaignAndEvent(campaignId, eventId) } returns override
-        assertEquals(override, service.findByCampaignAndEvent(campaignId, eventId))
+        service.findByCampaignAndEvent(campaignId, eventId) shouldBe override
     }
 
     @Test
     fun `persist should call repository persist`() {
         val override = CampaignEventOverride()
         every { repository.persist(override) } returns 1
-        assertEquals(1, service.persist(override))
+        service.persist(override) shouldBe 1
     }
 
     @Test
@@ -72,7 +74,7 @@ class CampaignEventServiceTest {
     fun `applyOverride should return null for DELETE`() {
         val base = TimelineEvent().apply { id = UUID.randomUUID() }
         val override = CampaignEventOverride().apply { overrideMode = OverrideMode.DELETE }
-        assertNull(service.applyOverride(base, override))
+        service.applyOverride(base, override).shouldBeNull()
     }
 
     @Test
@@ -85,8 +87,8 @@ class CampaignEventServiceTest {
             this.payload = payload
         }
         val result = service.applyOverride(base, override)
-        assertNotNull(result)
-        assertEquals(base.id, result?.id)
+        result shouldNotBe null
+        result?.id shouldBe base.id
     }
 
     @Test
@@ -98,8 +100,8 @@ class CampaignEventServiceTest {
         }
         every { merge.merge(any<String>(), any<String>()) } returns "{\"id\":\"${base.id}\",\"title\":\"new\"}"
         val result = service.applyOverride(base, override)
-        assertNotNull(result)
-        assertEquals("new", result?.title)
+        result shouldNotBe null
+        result?.title shouldBe "new"
     }
 
     @Test
@@ -107,6 +109,6 @@ class CampaignEventServiceTest {
         val base = TimelineEvent().apply { id = UUID.randomUUID() }
         val override = CampaignEventOverride().apply { overrideMode = null }
         val result = service.applyOverride(base, override)
-        assertEquals(base, result)
+        result shouldBe base
     }
 }

--- a/src/test/kotlin/org/fg/ttrpg/campaign/CampaignServiceTest.kt
+++ b/src/test/kotlin/org/fg/ttrpg/campaign/CampaignServiceTest.kt
@@ -2,7 +2,9 @@ package org.fg.ttrpg.campaign
 
 import io.mockk.every
 import io.mockk.mockk
-import org.junit.jupiter.api.Assertions.*
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.nulls.shouldBeNull
 import org.junit.jupiter.api.Test
 import java.util.*
 
@@ -17,8 +19,8 @@ class CampaignServiceTest {
         every { campaignRepository.findById(id) } returns campaign
 
         val result = service.findById(id)
-        assertNotNull(result)
-        assertEquals(id, result?.id)
+        result shouldNotBe null
+        result?.id shouldBe id
     }
 
     @Test
@@ -27,7 +29,7 @@ class CampaignServiceTest {
         every { campaignRepository.findById(id) } returns null
 
         val result = service.findById(id)
-        assertNull(result)
+        result.shouldBeNull()
     }
 
     @Test
@@ -37,7 +39,7 @@ class CampaignServiceTest {
         every { campaignRepository.listByGm(gmId) } returns campaigns
 
         val result = service.listAll(gmId)
-        assertEquals(campaigns, result)
+        result shouldBe campaigns
     }
 
     @Test
@@ -48,8 +50,8 @@ class CampaignServiceTest {
         every { campaignRepository.findByIdForGm(id, gmId) } returns campaign
 
         val result = service.findByIdForGm(id, gmId)
-        assertNotNull(result)
-        assertEquals(id, result?.id)
+        result shouldNotBe null
+        result?.id shouldBe id
     }
 
     @Test


### PR DESCRIPTION
## Summary
- replace JUnit assertions with Kotest matchers
- clean up imports to use Kotest

## Testing
- `./gradlew test` *(fails: Could not find a valid Docker environment)*

------
https://chatgpt.com/codex/tasks/task_e_685afc5ae4dc83259af14fc9bb053031