### PR TITLE
Add timeline object usage view and repository

### DIFF
--- a/src/main/kotlin/org/fg/ttrpg/timeline/TimelineObjectUsage.kt
+++ b/src/main/kotlin/org/fg/ttrpg/timeline/TimelineObjectUsage.kt
@@ -1,0 +1,9 @@
+package org.fg.ttrpg.timeline
+
+import java.util.UUID
+
+/** Mapping of a timeline event to a referenced setting object. */
+data class TimelineObjectUsage(
+    val eventId: UUID,
+    val settingObjectId: UUID,
+)

--- a/src/main/kotlin/org/fg/ttrpg/timeline/TimelineObjectUsageRepository.kt
+++ b/src/main/kotlin/org/fg/ttrpg/timeline/TimelineObjectUsageRepository.kt
@@ -1,0 +1,41 @@
+package org.fg.ttrpg.timeline
+
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import org.jdbi.v3.core.Jdbi
+import org.jdbi.v3.core.mapper.RowMapper
+import org.jdbi.v3.core.statement.StatementContext
+import java.sql.ResultSet
+import java.util.UUID
+
+@ApplicationScoped
+class TimelineObjectUsageRepository @Inject constructor(private val jdbi: Jdbi) {
+
+    fun listObjectsForEvent(eventId: UUID): List<TimelineObjectUsage> =
+        jdbi.withHandle<List<TimelineObjectUsage>, Exception> { handle ->
+            handle.createQuery(
+                "SELECT event_id, setting_object_id FROM timeline_object_usage WHERE event_id = :eid"
+            )
+                .bind("eid", eventId)
+                .map(TimelineObjectUsageMapper())
+                .list()
+        }
+
+    fun listEventsForObject(objectId: UUID): List<TimelineObjectUsage> =
+        jdbi.withHandle<List<TimelineObjectUsage>, Exception> { handle ->
+            handle.createQuery(
+                "SELECT event_id, setting_object_id FROM timeline_object_usage WHERE setting_object_id = :oid"
+            )
+                .bind("oid", objectId)
+                .map(TimelineObjectUsageMapper())
+                .list()
+        }
+
+    private class TimelineObjectUsageMapper : RowMapper<TimelineObjectUsage> {
+        override fun map(rs: ResultSet, ctx: StatementContext): TimelineObjectUsage =
+            TimelineObjectUsage(
+                rs.getObject("event_id", UUID::class.java),
+                rs.getObject("setting_object_id", UUID::class.java),
+            )
+    }
+}

--- a/src/main/kotlin/org/fg/ttrpg/timeline/TimelineService.kt
+++ b/src/main/kotlin/org/fg/ttrpg/timeline/TimelineService.kt
@@ -5,7 +5,10 @@ import jakarta.inject.Inject
 import java.util.UUID
 
 @ApplicationScoped
-class TimelineService @Inject constructor(private val repository: TimelineEventRepository) {
+class TimelineService @Inject constructor(
+    private val repository: TimelineEventRepository,
+    private val usageRepository: TimelineObjectUsageRepository,
+) {
     fun listByCalendar(calendarId: UUID): List<TimelineEvent> =
         repository.listByCalendar(calendarId)
 
@@ -17,4 +20,10 @@ class TimelineService @Inject constructor(private val repository: TimelineEventR
     fun persist(event: TimelineEvent) {
         repository.persist(event)
     }
+
+    fun listObjectsForEvent(eventId: UUID): List<TimelineObjectUsage> =
+        usageRepository.listObjectsForEvent(eventId)
+
+    fun listEventsForObject(objectId: UUID): List<TimelineObjectUsage> =
+        usageRepository.listEventsForObject(objectId)
 }

--- a/src/main/resources/db/changelog/8-timeline_object_view.sql
+++ b/src/main/resources/db/changelog/8-timeline_object_view.sql
@@ -1,0 +1,3 @@
+CREATE OR REPLACE VIEW timeline_object_usage AS
+SELECT te.id AS event_id, unnest(te.object_refs) AS setting_object_id
+FROM timeline_event te;

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -48,3 +48,10 @@ databaseChangeLog:
         - sqlFile:
             path: 7-campaign_object_view.sql
             relativeToChangelogFile: true
+  - changeSet:
+      id: 8-timeline-object-view
+      author: codex
+      changes:
+        - sqlFile:
+            path: 8-timeline_object_view.sql
+            relativeToChangelogFile: true

--- a/src/test/kotlin/org/fg/ttrpg/timeline/TimelineObjectUsageRepositoryIT.kt
+++ b/src/test/kotlin/org/fg/ttrpg/timeline/TimelineObjectUsageRepositoryIT.kt
@@ -1,0 +1,80 @@
+package org.fg.ttrpg.timeline
+
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import io.quarkus.test.TestTransaction
+import io.quarkus.test.junit.QuarkusTest
+import jakarta.inject.Inject
+import jakarta.transaction.Transactional
+import org.fg.ttrpg.calendar.CalendarSystem
+import org.fg.ttrpg.calendar.CalendarSystemRepository
+import org.fg.ttrpg.setting.*
+import org.fg.ttrpg.testutils.IntegrationTestHelper
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.*
+
+@QuarkusTest
+class TimelineObjectUsageRepositoryIT : IntegrationTestHelper() {
+
+    @Inject
+    lateinit var objectRepo: SettingObjectRepository
+
+    @Inject
+    lateinit var calendarRepo: CalendarSystemRepository
+
+    @Inject
+    lateinit var eventRepo: TimelineEventRepository
+
+    @Inject
+    lateinit var usageRepo: TimelineObjectUsageRepository
+
+    @Transactional
+    fun createSettingObject(id: UUID, setting: Setting, template: Template, gmId: UUID): SettingObject {
+        val gm = gmRepo.findById(gmId)
+        return SettingObject().apply {
+            this.id = id
+            slug = "slug-$id"
+            title = "obj"
+            payload = "{}"
+            createdAt = Instant.now()
+            this.setting = setting
+            this.template = template
+            this.gm = gm
+        }.also { objectRepo.persist(it) }
+    }
+
+    @Test
+    @TestTransaction
+    fun `usage view returns expected rows`() {
+        val gm = createGm(UUID.randomUUID())
+        val setting = createSetting(UUID.randomUUID(), gm.id!!)
+        val template = createTemplate(UUID.randomUUID(), gm.id!!, "{}")
+        val obj1 = createSettingObject(UUID.randomUUID(), setting, template, gm.id!!)
+        val obj2 = createSettingObject(UUID.randomUUID(), setting, template, gm.id!!)
+
+        val cal = CalendarSystem().apply {
+            id = UUID.randomUUID()
+            name = "cal"
+            epochLabel = "CE"
+            months = "[]"
+            this.setting = setting
+        }
+        calendarRepo.persist(cal)
+
+        val event = TimelineEvent().apply {
+            id = UUID.randomUUID()
+            title = "evt"
+            startDay = 1
+            calendar = cal
+            objectRefs = mutableListOf(obj1, obj2)
+        }
+        eventRepo.persist(event)
+
+        val objects = usageRepo.listObjectsForEvent(event.id!!)
+        objects.map { it.settingObjectId } shouldContainExactlyInAnyOrder listOf(obj1.id, obj2.id)
+
+        val events = usageRepo.listEventsForObject(obj1.id!!)
+        events.map { it.eventId } shouldBe listOf(event.id)
+    }
+}


### PR DESCRIPTION
## Summary
- add SQL view for timeline object usage
- update Liquibase changelog to include new view
- implement `TimelineObjectUsage` data class and repository
- expose new repository via `TimelineService`
- add integration test for timeline object usage queries

## Testing
- `./gradlew test --no-daemon` *(fails: Could not find a valid Docker environment)*

------
https://chatgpt.com/codex/tasks/task_e_685bde3c4e6c832589aa728f7a2d3bad