### PR TITLE
Add tag support for SettingObject

### DIFF
--- a/src/main/kotlin/org/fg/ttrpg/setting/SettingObjectTag.kt
+++ b/src/main/kotlin/org/fg/ttrpg/setting/SettingObjectTag.kt
@@ -1,0 +1,9 @@
+package org.fg.ttrpg.setting
+
+/**
+ * Represents a tag attached to a [SettingObject].
+ */
+class SettingObjectTag {
+    var settingObject: SettingObject? = null
+    var tag: String? = null
+}

--- a/src/main/kotlin/org/fg/ttrpg/setting/SettingObjectTagRepository.kt
+++ b/src/main/kotlin/org/fg/ttrpg/setting/SettingObjectTagRepository.kt
@@ -1,0 +1,32 @@
+package org.fg.ttrpg.setting
+
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import org.jdbi.v3.core.Jdbi
+import java.util.UUID
+
+@ApplicationScoped
+class SettingObjectTagRepository @Inject constructor(private val jdbi: Jdbi) {
+
+    fun listBySettingObject(id: UUID): List<String> =
+        jdbi.withHandle<List<String>, Exception> { handle ->
+            handle.createQuery("SELECT tag FROM setting_object_tags WHERE setting_object_id = :id")
+                .bind("id", id)
+                .mapTo(String::class.java)
+                .list()
+        }
+
+    fun replaceForObject(id: UUID, tags: List<String>) {
+        jdbi.useHandle<Exception> { handle ->
+            handle.createUpdate("DELETE FROM setting_object_tags WHERE setting_object_id = :id")
+                .bind("id", id)
+                .execute()
+            tags.forEach { tag ->
+                handle.createUpdate("INSERT INTO setting_object_tags (setting_object_id, tag) VALUES (:id, :tag)")
+                    .bind("id", id)
+                    .bind("tag", tag)
+                    .execute()
+            }
+        }
+    }
+}

--- a/src/test/kotlin/org/fg/ttrpg/repository/RepositoryIT.kt
+++ b/src/test/kotlin/org/fg/ttrpg/repository/RepositoryIT.kt
@@ -152,11 +152,13 @@ class RepositoryIT {
             this.setting = setting
             this.template = template
             this.gm = gm
+            tags = mutableListOf("foo", "bar")
         }
         objectRepo.persist(obj)
 
         val found = objectRepo.findByIdForGm(obj.id!!, gm.id!!)
         found?.slug shouldBe "slug"
+        found?.tags shouldBe listOf("foo", "bar")
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add SettingObjectTag entity and repository
- load and save tags for SettingObject
- verify tags round-trip in repository integration tests

## Testing
- `./gradlew test --no-daemon` *(fails: Could not find a valid Docker environment)*

------
https://chatgpt.com/codex/tasks/task_e_685bde3a97d883259d66dfd42c4be3c9