### PR TITLE
Add auth tables and repositories

### DIFF
--- a/src/main/kotlin/org/fg/ttrpg/auth/ObjectGrant.kt
+++ b/src/main/kotlin/org/fg/ttrpg/auth/ObjectGrant.kt
@@ -1,0 +1,13 @@
+package org.fg.ttrpg.auth
+
+import java.time.Instant
+import java.util.UUID
+
+class ObjectGrant {
+    var id: UUID? = null
+    var user: User? = null
+    var objectId: UUID? = null
+    var permission: Permission? = null
+    var grantedBy: User? = null
+    var grantTime: Instant? = null
+}

--- a/src/main/kotlin/org/fg/ttrpg/auth/ObjectGrantRepository.kt
+++ b/src/main/kotlin/org/fg/ttrpg/auth/ObjectGrantRepository.kt
@@ -1,0 +1,25 @@
+package org.fg.ttrpg.auth
+
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import org.jdbi.v3.core.Jdbi
+
+@ApplicationScoped
+class ObjectGrantRepository @Inject constructor(private val jdbi: Jdbi) {
+
+    fun persist(grant: ObjectGrant) {
+        jdbi.useHandle<Exception> { handle ->
+            handle.createUpdate(
+                "INSERT INTO object_grant (id, user_id, object_id, permission_id, granted_by, grant_time) " +
+                    "VALUES (:id, :userId, :objectId, :permissionId, :grantedBy, :grantTime)"
+            )
+                .bind("id", grant.id)
+                .bind("userId", grant.user?.id)
+                .bind("objectId", grant.objectId)
+                .bind("permissionId", grant.permission?.id)
+                .bind("grantedBy", grant.grantedBy?.id)
+                .bind("grantTime", grant.grantTime)
+                .execute()
+        }
+    }
+}

--- a/src/main/kotlin/org/fg/ttrpg/auth/Permission.kt
+++ b/src/main/kotlin/org/fg/ttrpg/auth/Permission.kt
@@ -1,0 +1,8 @@
+package org.fg.ttrpg.auth
+
+import java.util.UUID
+
+class Permission {
+    var id: UUID? = null
+    var code: String? = null
+}

--- a/src/main/kotlin/org/fg/ttrpg/auth/PermissionRepository.kt
+++ b/src/main/kotlin/org/fg/ttrpg/auth/PermissionRepository.kt
@@ -1,0 +1,38 @@
+package org.fg.ttrpg.auth
+
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import org.jdbi.v3.core.Jdbi
+import org.jdbi.v3.core.mapper.RowMapper
+import org.jdbi.v3.core.statement.StatementContext
+import java.sql.ResultSet
+import java.util.UUID
+
+@ApplicationScoped
+class PermissionRepository @Inject constructor(private val jdbi: Jdbi) {
+
+    fun findById(id: UUID): Permission? =
+        jdbi.withHandle<Permission?, Exception> { handle ->
+            handle.createQuery("SELECT id, code FROM permission WHERE id = :id")
+                .bind("id", id)
+                .map(PermissionMapper())
+                .findOne()
+                .orElse(null)
+        }
+
+    fun persist(permission: Permission) {
+        jdbi.useHandle<Exception> { handle ->
+            handle.createUpdate("INSERT INTO permission (id, code) VALUES (:id, :code)")
+                .bind("id", permission.id)
+                .bind("code", permission.code)
+                .execute()
+        }
+    }
+
+    private class PermissionMapper : RowMapper<Permission> {
+        override fun map(rs: ResultSet, ctx: StatementContext): Permission = Permission().apply {
+            id = rs.getObject("id", UUID::class.java)
+            code = rs.getString("code")
+        }
+    }
+}

--- a/src/main/kotlin/org/fg/ttrpg/auth/Role.kt
+++ b/src/main/kotlin/org/fg/ttrpg/auth/Role.kt
@@ -1,0 +1,8 @@
+package org.fg.ttrpg.auth
+
+import java.util.UUID
+
+class Role {
+    var id: UUID? = null
+    var code: String? = null
+}

--- a/src/main/kotlin/org/fg/ttrpg/auth/RoleRepository.kt
+++ b/src/main/kotlin/org/fg/ttrpg/auth/RoleRepository.kt
@@ -1,0 +1,38 @@
+package org.fg.ttrpg.auth
+
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import org.jdbi.v3.core.Jdbi
+import org.jdbi.v3.core.mapper.RowMapper
+import org.jdbi.v3.core.statement.StatementContext
+import java.sql.ResultSet
+import java.util.UUID
+
+@ApplicationScoped
+class RoleRepository @Inject constructor(private val jdbi: Jdbi) {
+
+    fun findById(id: UUID): Role? =
+        jdbi.withHandle<Role?, Exception> { handle ->
+            handle.createQuery("SELECT id, code FROM role WHERE id = :id")
+                .bind("id", id)
+                .map(RoleMapper())
+                .findOne()
+                .orElse(null)
+        }
+
+    fun persist(role: Role) {
+        jdbi.useHandle<Exception> { handle ->
+            handle.createUpdate("INSERT INTO role (id, code) VALUES (:id, :code)")
+                .bind("id", role.id)
+                .bind("code", role.code)
+                .execute()
+        }
+    }
+
+    private class RoleMapper : RowMapper<Role> {
+        override fun map(rs: ResultSet, ctx: StatementContext): Role = Role().apply {
+            id = rs.getObject("id", UUID::class.java)
+            code = rs.getString("code")
+        }
+    }
+}

--- a/src/main/kotlin/org/fg/ttrpg/auth/User.kt
+++ b/src/main/kotlin/org/fg/ttrpg/auth/User.kt
@@ -1,0 +1,11 @@
+package org.fg.ttrpg.auth
+
+import org.fg.ttrpg.account.GM
+import java.util.UUID
+
+class User {
+    var id: UUID? = null
+    var username: String? = null
+    var email: String? = null
+    var gm: GM? = null
+}

--- a/src/main/kotlin/org/fg/ttrpg/auth/UserRepository.kt
+++ b/src/main/kotlin/org/fg/ttrpg/auth/UserRepository.kt
@@ -1,0 +1,43 @@
+package org.fg.ttrpg.auth
+
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import org.fg.ttrpg.account.GM
+import org.jdbi.v3.core.Jdbi
+import org.jdbi.v3.core.mapper.RowMapper
+import org.jdbi.v3.core.statement.StatementContext
+import java.sql.ResultSet
+import java.util.UUID
+
+@ApplicationScoped
+class UserRepository @Inject constructor(private val jdbi: Jdbi) {
+
+    fun findById(id: UUID): User? =
+        jdbi.withHandle<User?, Exception> { handle ->
+            handle.createQuery("SELECT id, username, email, gm_id FROM \"user\" WHERE id = :id")
+                .bind("id", id)
+                .map(UserMapper())
+                .findOne()
+                .orElse(null)
+        }
+
+    fun persist(user: User) {
+        jdbi.useHandle<Exception> { handle ->
+            handle.createUpdate("INSERT INTO \"user\" (id, username, email, gm_id) VALUES (:id, :username, :email, :gmId)")
+                .bind("id", user.id)
+                .bind("username", user.username)
+                .bind("email", user.email)
+                .bind("gmId", user.gm?.id)
+                .execute()
+        }
+    }
+
+    private class UserMapper : RowMapper<User> {
+        override fun map(rs: ResultSet, ctx: StatementContext): User = User().apply {
+            id = rs.getObject("id", UUID::class.java)
+            username = rs.getString("username")
+            email = rs.getString("email")
+            gm = GM().apply { id = rs.getObject("gm_id", UUID::class.java) }
+        }
+    }
+}

--- a/src/main/resources/db/changelog/9-auth.sql
+++ b/src/main/resources/db/changelog/9-auth.sql
@@ -1,0 +1,34 @@
+CREATE TABLE "user" (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    username VARCHAR(255) NOT NULL,
+    email VARCHAR(255),
+    gm_id UUID NOT NULL REFERENCES gm(id) ON DELETE CASCADE
+);
+
+CREATE TABLE role (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    code VARCHAR(255) NOT NULL UNIQUE
+);
+
+CREATE TABLE permission (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    code VARCHAR(255) NOT NULL UNIQUE
+);
+
+CREATE TABLE user_role (
+    user_id UUID NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+    role_id UUID NOT NULL REFERENCES role(id) ON DELETE CASCADE,
+    PRIMARY KEY (user_id, role_id)
+);
+
+CREATE TABLE object_grant (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+    object_id UUID NOT NULL,
+    permission_id UUID NOT NULL REFERENCES permission(id),
+    granted_by UUID REFERENCES "user"(id),
+    grant_time TIMESTAMP NOT NULL DEFAULT now()
+);
+
+CREATE INDEX object_grant_user_idx ON object_grant(user_id);
+CREATE INDEX object_grant_object_idx ON object_grant(object_id);

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -55,3 +55,10 @@ databaseChangeLog:
         - sqlFile:
             path: 8-timeline_object_view.sql
             relativeToChangelogFile: true
+  - changeSet:
+      id: 9-auth
+      author: codex
+      changes:
+        - sqlFile:
+            path: 9-auth.sql
+            relativeToChangelogFile: true

--- a/src/test/kotlin/org/fg/ttrpg/testutils/IntegrationTestHelper.kt
+++ b/src/test/kotlin/org/fg/ttrpg/testutils/IntegrationTestHelper.kt
@@ -10,6 +10,8 @@ import org.fg.ttrpg.campaign.Campaign
 import org.fg.ttrpg.campaign.CampaignRepository
 import org.fg.ttrpg.common.dto.CalendarDTO
 import org.fg.ttrpg.common.dto.TimelineEventDTO
+import org.fg.ttrpg.auth.User
+import org.fg.ttrpg.auth.UserRepository
 import org.fg.ttrpg.setting.*
 import org.junit.jupiter.api.AfterEach
 import java.time.Instant
@@ -31,6 +33,9 @@ open class IntegrationTestHelper {
     @Inject
     lateinit var genreRepo: org.fg.ttrpg.genre.GenreRepository
 
+    @Inject
+    lateinit var userRepo: UserRepository
+
     private val gmIds = mutableListOf<UUID>()
 
     @AfterEach
@@ -46,6 +51,12 @@ open class IntegrationTestHelper {
             username = "gm-$id"
         }
         gmRepo.persist(gm)
+        val user = User().apply {
+            this.id = UUID.randomUUID()
+            username = "user-$id"
+            this.gm = gm
+        }
+        userRepo.persist(user)
         gmIds.add(id)
         return gm
     }


### PR DESCRIPTION
## Summary
- add Liquibase migration for auth tables
- wire new migration in `db.changelog-master.yaml`
- implement `User`, `Role`, `Permission`, `ObjectGrant` and repositories
- adjust integration test helper to create a default user

## Testing
- `./gradlew test --no-daemon` *(fails: Could not find a valid Docker environment)*

------
https://chatgpt.com/codex/tasks/task_e_685c04d921188325ac9e534d27e0e21d